### PR TITLE
add billing header

### DIFF
--- a/src/claude.js
+++ b/src/claude.js
@@ -1,8 +1,28 @@
 'use strict';
 
-const { spawn } = require('child_process');
+const { spawn, execSync } = require('child_process');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
+
+/**
+ * Dynamically resolve the billing header from the installed Claude CLI version.
+ * This ensures Bridge always sends a valid header regardless of CLI version.
+ */
+function resolveBillingHeader() {
+    try {
+        const versionOutput = execSync(`${CLAUDE_BIN} --version`, { cwd: '/tmp', timeout: 5000 }).toString().trim();
+        // Output format: "2.1.89 (Claude Code)" or "claude 2.1.89.0fc" — handle both
+        const match = versionOutput.match(/([0-9]+\.[0-9]+\.[0-9]+(?:\.\w+)?)/);
+        const version = match ? match[1] : 'unknown';
+        return `x-anthropic-billing-header: cc_version=${version}; cc_entrypoint=cli; cch=00000;`;
+    } catch {
+        // Fallback: use a generic header if CLI --version fails (e.g. in tests)
+        return 'x-anthropic-billing-header: cc_version=unknown; cc_entrypoint=cli; cch=00000;';
+    }
+}
+
+/** Billing header injected into every system prompt so Anthropic counts this as CLI traffic. */
+const BILLING_HEADER = process.env.BILLING_HEADER || resolveBillingHeader();
 
 /**
  * Map OpenClaw model IDs to Claude CLI model names.
@@ -80,8 +100,9 @@ function runClaude(systemPrompt, promptText, modelId, onChunk, signal, reasoning
         }
 
         // Replace Claude Code default system prompt (removes ~15-20KB of irrelevant noise)
+        // Prepend billing header so Anthropic recognizes this as CLI traffic (Pro/Max subscription).
         if (systemPrompt) {
-            args.push('--system-prompt', systemPrompt);
+            args.push('--system-prompt', BILLING_HEADER + systemPrompt);
         }
 
         // Always disable native tools (CLI flag, not session property)


### PR DESCRIPTION
## Problem               
OpenClaw users were getting 400 errors ("You're out of extra usage") even with active Pro/Max subscriptions.                                                       

## Root Cause                                                                       
Bridge was not sending the `x-anthropic-billing-header` that Anthropic uses to identify CLI traffic. Without it, requests were billed against Extra Usage instead of the subscription quota.                                                          

## Fix                                                    
- Dynamically resolve CLI version via `claude --version` at startup                
- Inject `x-anthropic-billing-header: cc_version=<version>; cc_entrypoint=cli; cch=00000;` at the start of every system prompt
         