### PR TITLE
fix: robustly extract JSON from tool_call blocks

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -277,15 +277,27 @@ function parseToolCalls(text) {
     const calls = [];
     let match;
     while ((match = regex.exec(text)) !== null) {
+        const raw = (match[1] || '').trim();
+        const start = raw.indexOf('{');
+        const end = raw.lastIndexOf('}');
+        if (start === -1 || end === -1 || end < start) {
+            console.error(`[parseToolCalls] No JSON object found in block: ${raw.slice(0, 300)}`);
+            continue;
+        }
+        const jsonText = raw.slice(start, end + 1);
         try {
-            const parsed = JSON.parse(match[1]);
+            const parsed = JSON.parse(jsonText);
+            if (!parsed || typeof parsed.name !== 'string') {
+                console.error(`[parseToolCalls] Invalid tool_call payload: ${jsonText.slice(0, 300)}`);
+                continue;
+            }
             calls.push({
                 id: `call_${uuidv4().slice(0, 8)}`,
                 name: parsed.name,
                 arguments: parsed.arguments || {},
             });
         } catch (err) {
-            console.error(`[parseToolCalls] Failed to parse: ${match[1]}`);
+            console.error(`[parseToolCalls] Failed to parse JSON: ${jsonText.slice(0, 300)}`);
         }
     }
     return calls;


### PR DESCRIPTION
## Summary
- make `parseToolCalls()` extract the JSON object inside each `<tool_call>` block before parsing
- tolerate Claude responses that include extra prose around the JSON payload inside a tool block
- improve logging for invalid or non-JSON tool blocks

## Why
In practice Claude can sometimes emit mixed output around tool calls. The previous implementation assumed the entire `<tool_call>` body was clean JSON, which caused tool-call parsing to fail and returned text where OpenClaw expected structured tool calls.

## Example symptom
Bridge logs showed errors like:
- `[parseToolCalls] Failed to parse: ...`
followed by conversational text and then a valid `<tool_call>` payload.

This change makes the parser more forgiving without changing the wire format.
