### PR TITLE
fix: strip tool_thinking tags from responses

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -298,6 +298,7 @@ function parseToolCalls(text) {
 function cleanResponseText(text) {
     if (!text) return text;
     return text
+        .replace(/<tool_thinking>[\s\S]*?<\/tool_thinking>/g, '')
         .replace(/<tool_call>[\s\S]*?<\/tool_call>/g, '')
         .replace(/<tool_result[\s\S]*?<\/tool_result>/g, '')
         .replace(/<previous_response>[\s\S]*?<\/previous_response>/g, '')

--- a/src/server.js
+++ b/src/server.js
@@ -302,6 +302,7 @@ function cleanResponseText(text) {
         .replace(/<tool_call>[\s\S]*?<\/tool_call>/g, '')
         .replace(/<tool_result[\s\S]*?<\/tool_result>/g, '')
         .replace(/<previous_response>[\s\S]*?<\/previous_response>/g, '')
+        .replace(/\n{3,}/g, '\n\n')
         .trim();
 }
 


### PR DESCRIPTION
## Summary
- strip leaked `<tool_thinking>...</tool_thinking>` blocks from bridge responses
- keep internal bridge tags out of end-user chat output

## Why
Claude can emit `<tool_thinking>` blocks, but `cleanResponseText()` was only removing `<tool_call>`, `<tool_result>`, and `<previous_response>`. That leaked internal reasoning wrapper text into user-visible chat.

## Testing
- sanity-checked `cleanResponseText()` with a sample response containing both `<tool_thinking>` and `<tool_call>` blocks
- confirmed only the user-facing answer remains