### PR TITLE
fix: pass --strict-mcp-config to prevent user MCP leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ openclaw-claude-bridge/
 - **Port 3456** binds to localhost only — not reachable from outside the machine
 - **Port 3458** is LAN-accessible, protected by HTTP Basic Auth when `DASHBOARD_PASS` is set
 - **`--tools ""`** disables all Claude native tools — no host command execution
+- **`--strict-mcp-config`** disables all MCP servers — no host MCP leak into the bridged session
 - **`--dangerously-skip-permissions`** is required for headless operation (no terminal to prompt for confirmation; safe because native tools are disabled)
 - **`.env`** contains secrets and is gitignored
 

--- a/src/claude.js
+++ b/src/claude.js
@@ -238,6 +238,8 @@ function runClaude(systemPrompt, promptText, modelId, onChunk, signal, reasoning
 
         // Always disable native tools (CLI flag, not session property)
         args.push('--tools', '');
+        // Block user MCP servers from leaking into Claude's tool context
+        args.push('--strict-mcp-config');
 
         // Map OC reasoning_effort → Claude CLI --effort
         const effort = mapEffort(reasoningEffort);


### PR DESCRIPTION
## Summary

Pass `--strict-mcp-config` to the spawned Claude CLI so that MCP servers configured on the host (e.g. in `~/.claude.json`) are not loaded into the bridged session. Without `--mcp-config`, this disables all MCP sources, leaving only the tools OpenClaw declares.

## Guaranteed effects

- Prevents non-trivial context pollution: MCP server instructions and tool schemas are currently injected into the bridged Claude's system prompt without the bridge ever asking for them.
- Reduces token usage per request. Amount depends on the host's MCP configuration.

## Possible effect

Tool calls occasionally fail in bridged sessions. The cause is not confirmed, but this patch may help.

## Note

Authored via OpenClaw using `claude-opus-latest` (Opus 4.6) through this bridge.
