### PR TITLE
fix: skip brand substitution on tool_call args and tool_result content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 # Optional: Claude CLI model aliases (always points to latest version)
 # Change to opus[1m] / sonnet[1m] when 1M context window variants become available
 # OPUS_MODEL=opus
+# OPUS_47_MODEL=claude-opus-4-7
 # SONNET_MODEL=sonnet
 # HAIKU_MODEL=haiku
 

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
 # openclaw-claude-bridge environment variables
 # Copy this file to .env and fill in your values
 
-# Optional: Claude CLI model aliases (always points to latest version)
-# Change to opus[1m] / sonnet[1m] when 1M context window variants become available
-# OPUS_MODEL=opus
+# Optional: Claude CLI model overrides for explicit exposed model ids
+# Change to claude-opus-4-6[1m] / claude-sonnet-4-6[1m] when 1M variants are available
+# OPUS_MODEL=claude-opus-4-6
 # OPUS_47_MODEL=claude-opus-4-7
-# SONNET_MODEL=sonnet
-# HAIKU_MODEL=haiku
+# SONNET_MODEL=claude-sonnet-4-6
+# HAIKU_MODEL=claude-haiku-4-5
 
 # Optional: idle timeout — kill Claude CLI if no activity for this long (default 2 min)
 # Requests with active tool calls will never be killed regardless of total duration.

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ CLAUDE.md
 
 .runtime-backups/
 state.json.bak.*
+state/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ SECURITY-AUDIT.md
 # Internal docs — design notes, not for public
 docs/internal/
 CLAUDE.md
+
+.runtime-backups/
+state.json.bak.*

--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ For detailed architecture of the dashboard, see [docs/architecture.md](docs/arch
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `DASHBOARD_PASS` | No | — | Dashboard password (Basic Auth, user: `admin`) |
-| `OPUS_MODEL` | No | `opus` | CLI model alias for Opus latest (use `opus[1m]` for 1M context) |
-| `OPUS_47_MODEL` | No | `claude-opus-4-7` | Exact Claude Opus 4.7 override for the explicit `claude-opus-4-7` model id |
-| `SONNET_MODEL` | No | `sonnet` | CLI model alias for Sonnet (use `sonnet[1m]` for 1M context) |
-| `HAIKU_MODEL` | No | `haiku` | CLI model alias for Haiku |
+| `OPUS_MODEL` | No | `claude-opus-4-6` | Claude CLI model override for `claude-opus-4-6` |
+| `OPUS_47_MODEL` | No | `claude-opus-4-7` | Claude CLI model override for `claude-opus-4-7` |
+| `SONNET_MODEL` | No | `claude-sonnet-4-6` | Claude CLI model override for `claude-sonnet-4-6` |
+| `HAIKU_MODEL` | No | `claude-haiku-4-5` | Claude CLI model override for `claude-haiku-4-5` |
 | `IDLE_TIMEOUT_MS` | No | `120000` | Kill CLI subprocess after this many ms of no output |
 | `OPENCLAW_BRIDGE_PORT` | No | `3456` | API server port |
 | `OPENCLAW_BRIDGE_STATUS_PORT` | No | `3458` | Dashboard port |
@@ -181,13 +181,6 @@ Add this provider to your OpenClaw config (`~/.openclaw/openclaw.json`):
         "api": "openai-completions",
         "models": [
           {
-            "id": "claude-opus-latest",
-            "name": "Claude Opus Latest",
-            "contextWindow": 1000000,
-            "maxTokens": 128000,
-            "reasoning": true
-          },
-          {
             "id": "claude-opus-4-7",
             "name": "Claude Opus 4.7",
             "contextWindow": 1000000,
@@ -195,10 +188,24 @@ Add this provider to your OpenClaw config (`~/.openclaw/openclaw.json`):
             "reasoning": true
           },
           {
-            "id": "claude-sonnet-latest",
-            "name": "Claude Sonnet",
+            "id": "claude-opus-4-6",
+            "name": "Claude Opus 4.6",
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "reasoning": true
+          },
+          {
+            "id": "claude-sonnet-4-6",
+            "name": "Claude Sonnet 4.6",
             "contextWindow": 1000000,
             "maxTokens": 64000,
+            "reasoning": true
+          },
+          {
+            "id": "claude-haiku-4-5",
+            "name": "Claude Haiku 4.5",
+            "contextWindow": 200000,
+            "maxTokens": 32000,
             "reasoning": true
           }
         ]

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ For detailed architecture of the dashboard, see [docs/architecture.md](docs/arch
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `DASHBOARD_PASS` | No | — | Dashboard password (Basic Auth, user: `admin`) |
-| `OPUS_MODEL` | No | `opus` | CLI model alias for Opus (use `opus[1m]` for 1M context) |
+| `OPUS_MODEL` | No | `opus` | CLI model alias for Opus latest (use `opus[1m]` for 1M context) |
+| `OPUS_47_MODEL` | No | `claude-opus-4-7` | Exact Claude Opus 4.7 override for the explicit `claude-opus-4-7` model id |
 | `SONNET_MODEL` | No | `sonnet` | CLI model alias for Sonnet (use `sonnet[1m]` for 1M context) |
 | `HAIKU_MODEL` | No | `haiku` | CLI model alias for Haiku |
 | `IDLE_TIMEOUT_MS` | No | `120000` | Kill CLI subprocess after this many ms of no output |
@@ -181,7 +182,14 @@ Add this provider to your OpenClaw config (`~/.openclaw/openclaw.json`):
         "models": [
           {
             "id": "claude-opus-latest",
-            "name": "Claude Opus",
+            "name": "Claude Opus Latest",
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "reasoning": true
+          },
+          {
+            "id": "claude-opus-4-7",
+            "name": "Claude Opus 4.7",
             "contextWindow": 1000000,
             "maxTokens": 128000,
             "reasoning": true

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ Add this provider to your OpenClaw config (`~/.openclaw/openclaw.json`):
             "id": "claude-haiku-4-5",
             "name": "Claude Haiku 4.5",
             "contextWindow": 200000,
-            "maxTokens": 32000,
-            "reasoning": true
+            "maxTokens": 8192,
+            "reasoning": false
           }
         ]
       }

--- a/README.zh.md
+++ b/README.zh.md
@@ -204,8 +204,8 @@ Dashboard 詳細架構請參閱 [docs/architecture.md](docs/architecture.md#dash
             "id": "claude-haiku-4-5",
             "name": "Claude Haiku 4.5",
             "contextWindow": 200000,
-            "maxTokens": 32000,
-            "reasoning": true
+            "maxTokens": 8192,
+            "reasoning": false
           }
         ]
       }

--- a/README.zh.md
+++ b/README.zh.md
@@ -180,17 +180,31 @@ Dashboard 詳細架構請參閱 [docs/architecture.md](docs/architecture.md#dash
         "api": "openai-completions",
         "models": [
           {
-            "id": "claude-opus-latest",
-            "name": "Claude Opus",
+            "id": "claude-opus-4-7",
+            "name": "Claude Opus 4.7",
             "contextWindow": 1000000,
             "maxTokens": 128000,
             "reasoning": true
           },
           {
-            "id": "claude-sonnet-latest",
-            "name": "Claude Sonnet",
+            "id": "claude-opus-4-6",
+            "name": "Claude Opus 4.6",
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "reasoning": true
+          },
+          {
+            "id": "claude-sonnet-4-6",
+            "name": "Claude Sonnet 4.6",
             "contextWindow": 1000000,
             "maxTokens": 64000,
+            "reasoning": true
+          },
+          {
+            "id": "claude-haiku-4-5",
+            "name": "Claude Haiku 4.5",
+            "contextWindow": 200000,
+            "maxTokens": 32000,
             "reasoning": true
           }
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,59 +1,54 @@
 {
   "name": "openclaw-claude-bridge",
-  "version": "1.0.0",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-claude-bridge",
-      "version": "1.0.0",
+      "version": "1.2.3",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "express": "^4.18.2",
-        "uuid": "^9.0.0"
+        "express": "^5.2.1",
+        "uuid": "^14.0.0"
       }
     },
     "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
-    },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bytes": {
@@ -95,15 +90,16 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -125,18 +121,29 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/depd": {
@@ -146,16 +153,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/dunder-proto": {
@@ -233,45 +230,42 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
       },
       "funding": {
         "type": "opencollective",
@@ -279,21 +273,24 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/forwarded": {
@@ -306,12 +303,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/function-bind": {
@@ -385,9 +382,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -417,15 +414,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
@@ -443,6 +444,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -453,75 +460,61 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -551,6 +544,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -561,10 +563,14 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -580,9 +586,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -604,39 +610,35 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
+        "iconv-lite": "~0.7.0",
         "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -645,48 +647,48 @@
       "license": "MIT"
     },
     "node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -715,13 +717,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -786,13 +788,14 @@
       }
     },
     "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -807,26 +810,17 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -837,6 +831,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "commonjs",
   "scripts": {
     "start": "node src/index.js",
+    "test": "node scripts/test-tool-parser.js",
     "postinstall": "cd dashboard && npm install --ignore-scripts && npm run build"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "express": "^4.18.2",
-    "uuid": "^9.0.0"
+    "express": "^5.2.1",
+    "uuid": "^14.0.0"
   }
 }

--- a/scripts/start-bridge.sh
+++ b/scripts/start-bridge.sh
@@ -1,0 +1,12 @@
+#!/bin/zsh
+set -euo pipefail
+ENV_FILE="$HOME/.config/openclaw/claude-bridge.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "missing env file: $ENV_FILE" >&2
+  exit 1
+fi
+unset OPENAI_API_KEY
+set -a
+source "$ENV_FILE"
+set +a
+exec /opt/homebrew/bin/node src/index.js

--- a/scripts/test-tool-parser.js
+++ b/scripts/test-tool-parser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const { cleanResponseText, parseToolCallsDetailed } = require('../src/tool-parser');
+const { cleanResponseText, hasInternalBridgeMarkup, parseToolCallsDetailed, redactSensitivePreview } = require('../src/tool-parser');
 
 const allowed = new Set(['exec', 'read']);
 
@@ -51,6 +51,18 @@ const allowed = new Set(['exec', 'read']);
 {
     const cleaned = cleanResponseText('hello\n<tool_call>{"name":"exec","arguments":{"command":"echo nope"}}');
     assert.strictEqual(cleaned, 'hello');
+}
+
+{
+    assert.strictEqual(hasInternalBridgeMarkup('<tool_call>{"name":"exec"}'), true);
+    assert.strictEqual(hasInternalBridgeMarkup('plain text only'), false);
+}
+
+{
+    const redacted = redactSensitivePreview('OPENAI_API_KEY=sk-abc123456789 token=supersecret password=hunter2');
+    assert.ok(!redacted.includes('abc123456789'));
+    assert.ok(!redacted.includes('supersecret'));
+    assert.ok(!redacted.includes('hunter2'));
 }
 
 console.log('tool-parser tests passed');

--- a/scripts/test-tool-parser.js
+++ b/scripts/test-tool-parser.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const assert = require('assert');
+const { cleanResponseText, parseToolCallsDetailed } = require('../src/tool-parser');
+
+const allowed = new Set(['exec', 'read']);
+
+{
+    const result = parseToolCallsDetailed('<tool_call>{"name":"exec","arguments":{"command":"echo ok"}}</tool_call>', { allowedToolNames: allowed });
+    assert.strictEqual(result.calls.length, 1);
+    assert.strictEqual(result.repaired, false);
+    assert.strictEqual(result.calls[0].name, 'exec');
+    assert.deepStrictEqual(result.calls[0].arguments, { command: 'echo ok' });
+}
+
+{
+    const result = parseToolCallsDetailed('<tool_call>{"name":"exec","arguments":{"command":"grep x file"}}</tool_char>', { allowedToolNames: allowed });
+    assert.strictEqual(result.calls.length, 1);
+    assert.strictEqual(result.repaired, true);
+    assert.strictEqual(result.closeTag, '</tool_char>');
+    assert.strictEqual(result.calls[0].name, 'exec');
+}
+
+{
+    const result = parseToolCallsDetailed('prefix <tool_call>{"name":"read","arguments":{"path":"a"}}', { allowedToolNames: allowed });
+    assert.strictEqual(result.calls.length, 1);
+    assert.strictEqual(result.repaired, true);
+    assert.strictEqual(result.closeTag, 'EOF');
+    assert.strictEqual(result.calls[0].name, 'read');
+}
+
+{
+    const result = parseToolCallsDetailed('<tool_call>{"name":"gateway","arguments":{}}</tool_char>', { allowedToolNames: allowed });
+    assert.strictEqual(result.calls.length, 0);
+    assert.strictEqual(result.repaired, false);
+    assert.strictEqual(result.malformedReason, 'tool_not_allowed');
+}
+
+{
+    const result = parseToolCallsDetailed('<tool_call>{"name":"exec","arguments":{}}</tool_char><tool_call>{"name":"read","arguments":{}}</tool_char>', { allowedToolNames: allowed });
+    assert.strictEqual(result.calls.length, 0);
+    assert.strictEqual(result.repaired, false);
+    assert.strictEqual(result.malformedReason, 'multiple_tool_call_blocks');
+}
+
+{
+    const cleaned = cleanResponseText('hello\n<tool_call>{"name":"exec","arguments":{"command":"echo nope"}}</tool_char>\nworld');
+    assert.strictEqual(cleaned, 'hello\n\nworld');
+}
+
+{
+    const cleaned = cleanResponseText('hello\n<tool_call>{"name":"exec","arguments":{"command":"echo nope"}}');
+    assert.strictEqual(cleaned, 'hello');
+}
+
+console.log('tool-parser tests passed');

--- a/src/attachments.js
+++ b/src/attachments.js
@@ -1,0 +1,324 @@
+'use strict';
+
+/**
+ * Attachment handling for OpenClaw Claude Bridge.
+ *
+ * Claude Code CLI does NOT support @/path image references in text-mode stdin
+ * (--print without --input-format stream-json) — it interprets them as a request
+ * to use the (disabled) Read tool. The path that works is:
+ *
+ *   1. Pass --input-format stream-json --output-format stream-json --verbose
+ *   2. Feed stdin a JSON message in Anthropic Messages API shape:
+ *        {type: "user", message: {role: "user", content: [
+ *          {type: "text", text: "..."},
+ *          {type: "image", source: {type: "base64", media_type: "image/png", data: "..."}},
+ *          {type: "document", source: {type: "base64", media_type: "application/pdf", data: "..."}},
+ *        ]}}
+ *
+ * Verified against Claude CLI v2.1.98 with both Haiku and Sonnet — image content
+ * was correctly identified end-to-end. Originally implemented in
+ * Kyzcreig/hermes-claude-bridge v0.1.0; ported here with env-var rename.
+ *
+ * This module:
+ *   - inspects OpenAI content parts for non-text attachments
+ *   - returns a structured payload the runClaude path uses to choose
+ *     text-mode (no attachments, fast path) vs stream-json input mode
+ *
+ * Modes (controlled by env OPENCLAW_BRIDGE_ATTACHMENT_MODE):
+ *   - "passthrough" (default): emit Anthropic content blocks via stream-json input
+ *   - "describe": drop non-text parts entirely (caller is expected to have
+ *     described them upstream, e.g. via OpenClaw's imageModel routing).
+ *     Use this if you want to preserve the historical bridge behavior.
+ *
+ * Set OPENCLAW_BRIDGE_ATTACHMENT_MODE=describe to turn off native multimodal.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { execFileSync } = require('child_process');
+const { URL } = require('url');
+
+const MODE = process.env.OPENCLAW_BRIDGE_ATTACHMENT_MODE || 'passthrough';
+const PER_TURN_CAP = parseInt(process.env.OPENCLAW_BRIDGE_ATTACHMENT_PER_TURN_CAP) || 20;
+const SESSION_BUDGET_MB = parseInt(process.env.OPENCLAW_BRIDGE_ATTACHMENT_SESSION_BUDGET_MB) || 500;
+const DOWNLOAD_TIMEOUT_MS = parseInt(process.env.OPENCLAW_BRIDGE_ATTACHMENT_DOWNLOAD_TIMEOUT_MS) || 30000;
+const DOWNLOAD_MAX_BYTES = parseInt(process.env.OPENCLAW_BRIDGE_ATTACHMENT_DOWNLOAD_MAX_BYTES) || 50 * 1024 * 1024;
+
+// State dir for staging attachment bytes. OC bridge has no formal state dir
+// convention; default to <repo>/state/attachments unless OPENCLAW_BRIDGE_STATE_DIR
+// is set explicitly.
+const STATE_DIR = process.env.OPENCLAW_BRIDGE_STATE_DIR
+    || path.join(__dirname, '..', 'state');
+const ATTACH_DIR = path.join(STATE_DIR, 'attachments');
+
+try { fs.mkdirSync(ATTACH_DIR, { recursive: true }); } catch {}
+
+class AttachmentBudgetError extends Error {
+    constructor(message) { super(message); this.name = 'AttachmentBudgetError'; }
+}
+
+const IMAGE_MIMES = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/webp', 'image/gif']);
+const DOC_MIMES = new Set(['application/pdf']);  // CLI accepts PDF as "document"
+
+function _checkSessionBudget() {
+    try {
+        const files = fs.readdirSync(ATTACH_DIR);
+        let total = 0;
+        for (const f of files) {
+            try { total += fs.statSync(path.join(ATTACH_DIR, f)).size; } catch {}
+        }
+        const budgetBytes = SESSION_BUDGET_MB * 1024 * 1024;
+        if (total > budgetBytes) {
+            throw new AttachmentBudgetError(
+                `session disk budget exceeded (${Math.round(total/1024/1024)} MB > ${SESSION_BUDGET_MB} MB)`
+            );
+        }
+    } catch (err) {
+        if (err instanceof AttachmentBudgetError) throw err;
+    }
+}
+
+function _safeExt(name, fallback = 'bin') {
+    if (!name) return fallback;
+    const m = name.match(/\.([a-zA-Z0-9]{1,8})$/);
+    return m ? m[1].toLowerCase() : fallback;
+}
+
+function _extFromMime(mime) {
+    if (!mime) return null;
+    const map = {
+        'image/png': 'png',
+        'image/jpeg': 'jpg', 'image/jpg': 'jpg',
+        'image/webp': 'webp',
+        'image/gif': 'gif',
+        'application/pdf': 'pdf',
+        'text/plain': 'txt',
+        'text/markdown': 'md',
+        'application/json': 'json',
+    };
+    return map[mime.toLowerCase()] || null;
+}
+
+function _mimeFromExt(ext) {
+    const map = {
+        'png': 'image/png', 'jpg': 'image/jpeg', 'jpeg': 'image/jpeg',
+        'webp': 'image/webp', 'gif': 'image/gif',
+        'pdf': 'application/pdf',
+        'txt': 'text/plain', 'md': 'text/markdown', 'json': 'application/json',
+        'py': 'text/x-python', 'js': 'text/javascript', 'ts': 'text/typescript',
+    };
+    return map[(ext || '').toLowerCase()] || 'application/octet-stream';
+}
+
+function _parseDataUrl(url) {
+    const m = url.match(/^data:([^;,]+)?(;base64)?,(.*)$/s);
+    if (!m) return null;
+    const mime = m[1] || 'application/octet-stream';
+    const isBase64 = !!m[2];
+    const payload = m[3];
+    const buf = isBase64
+        ? Buffer.from(payload, 'base64')
+        : Buffer.from(decodeURIComponent(payload), 'utf8');
+    return { mime, buf };
+}
+
+function _downloadSync(url) {
+    const tmp = path.join(ATTACH_DIR, `.dl-${crypto.randomBytes(6).toString('hex')}.tmp`);
+    try {
+        execFileSync('curl', [
+            '-fsSL',
+            '--max-time', String(Math.floor(DOWNLOAD_TIMEOUT_MS / 1000)),
+            '--max-filesize', String(DOWNLOAD_MAX_BYTES),
+            '-o', tmp,
+            url,
+        ], { stdio: ['ignore', 'ignore', 'pipe'] });
+        const buf = fs.readFileSync(tmp);
+        return buf;
+    } finally {
+        try { fs.unlinkSync(tmp); } catch {}
+    }
+}
+
+/**
+ * Resolve an OpenAI content part to {bytes, mime, name} or null if not an
+ * attachment we handle. Used by classifyParts() to build Anthropic content
+ * blocks.
+ */
+function _resolveAttachment(part) {
+    let bytes = null;
+    let mime = null;
+    let name = null;
+
+    if (part.type === 'image_url' || part.type === 'input_image') {
+        const v = part.image_url;
+        const url = typeof v === 'string' ? v : (v && v.url);
+        if (!url) return null;
+
+        if (url.startsWith('data:')) {
+            const parsed = _parseDataUrl(url);
+            if (!parsed) return null;
+            bytes = parsed.buf; mime = parsed.mime;
+        } else if (/^https?:\/\//i.test(url)) {
+            bytes = _downloadSync(url);
+            try {
+                const u = new URL(url);
+                name = path.basename(u.pathname);
+                mime = _mimeFromExt(_safeExt(name));
+            } catch {}
+        } else if (url.startsWith('/') || url.startsWith('~') || url.startsWith('./')) {
+            const abs = url.startsWith('~')
+                ? path.join(process.env.HOME, url.slice(1))
+                : path.resolve(url);
+            if (!fs.existsSync(abs)) return null;
+            bytes = fs.readFileSync(abs);
+            name = path.basename(abs);
+            mime = _mimeFromExt(_safeExt(name));
+        } else {
+            return null;
+        }
+        // Force to a known image mime if extension says so
+        if (!IMAGE_MIMES.has((mime || '').toLowerCase())) {
+            const fromName = _mimeFromExt(_safeExt(name));
+            if (IMAGE_MIMES.has(fromName)) mime = fromName;
+            else mime = mime || 'image/png';  // best-effort default
+        }
+    } else if (part.type === 'file') {
+        const f = part.file || {};
+        name = f.filename || f.name || null;
+        if (f.file_data) {
+            try { bytes = Buffer.from(f.file_data, 'base64'); } catch { return null; }
+        } else if (f.file_url) {
+            bytes = _downloadSync(f.file_url);
+            if (!name) {
+                try { name = path.basename(new URL(f.file_url).pathname); } catch {}
+            }
+        } else if (f.path) {
+            const abs = path.resolve(f.path);
+            if (!fs.existsSync(abs)) return null;
+            bytes = fs.readFileSync(abs);
+            if (!name) name = path.basename(abs);
+        } else {
+            return null;
+        }
+        const ext = _safeExt(name);
+        mime = _mimeFromExt(ext);
+    } else {
+        return null;
+    }
+
+    if (!bytes) return null;
+    return { bytes, mime, name };
+}
+
+/**
+ * Given an OpenAI message's content (string or array of parts), classify it
+ * into:
+ *   - {text: string, attachments: [Anthropic content blocks]}
+ *
+ * In "passthrough" mode:
+ *   - images → Anthropic image content blocks (base64)
+ *   - PDFs → Anthropic document content blocks (base64)
+ *   - other files (text/code) → inlined as fenced code blocks in the text segment
+ *
+ * In "describe" mode: all non-text parts are dropped (preserves legacy
+ * imageModel-routing behavior).
+ *
+ * The caller decides whether the resulting message needs stream-json input
+ * (has attachments) or can use plain text mode (no attachments).
+ */
+function classifyParts(content, turnId) {
+    if (typeof content === 'string') {
+        return { text: content, attachments: [] };
+    }
+    if (content === null || content === undefined) {
+        return { text: '', attachments: [] };
+    }
+    if (!Array.isArray(content)) {
+        return { text: String(content ?? ''), attachments: [] };
+    }
+
+    const textSegments = [];
+    const attachments = [];
+    let count = 0;
+
+    for (const p of content) {
+        if (!p || typeof p !== 'object') continue;
+        if (p.type === 'text') {
+            if (p.text) textSegments.push(p.text);
+            continue;
+        }
+        if (MODE === 'describe') continue;
+
+        if (++count > PER_TURN_CAP) {
+            throw new AttachmentBudgetError(
+                `per-turn cap exceeded (${count} > ${PER_TURN_CAP})`
+            );
+        }
+        _checkSessionBudget();
+
+        let resolved;
+        try {
+            resolved = _resolveAttachment(p);
+        } catch (err) {
+            console.warn(`[attachments] resolve failed: ${err.message}`);
+            textSegments.push(`[attachment skipped: ${err.message}]`);
+            continue;
+        }
+        if (!resolved) {
+            textSegments.push('[attachment skipped: unrecognized format]');
+            continue;
+        }
+        const { bytes, mime, name } = resolved;
+
+        // Image → Anthropic image block
+        if (IMAGE_MIMES.has((mime || '').toLowerCase())) {
+            attachments.push({
+                type: 'image',
+                source: {
+                    type: 'base64',
+                    media_type: mime,
+                    data: bytes.toString('base64'),
+                },
+            });
+            continue;
+        }
+        // PDF → Anthropic document block
+        if (DOC_MIMES.has((mime || '').toLowerCase())) {
+            attachments.push({
+                type: 'document',
+                source: {
+                    type: 'base64',
+                    media_type: mime,
+                    data: bytes.toString('base64'),
+                },
+            });
+            continue;
+        }
+        // Text/code file → inline as fenced block in the text segment.
+        // Cheap, lossless for the use cases (configs, source files, logs).
+        // Also persist the file to state/attachments/ for debugging.
+        try {
+            const ext = _extFromMime(mime) || _safeExt(name, 'txt');
+            const slug = `${turnId}-${count}-${crypto.randomBytes(3).toString('hex')}.${ext}`;
+            fs.writeFileSync(path.join(ATTACH_DIR, slug), bytes);
+        } catch {}
+        const lang = _safeExt(name, '');
+        const asText = bytes.toString('utf8');
+        const displayName = name || `attachment.${_extFromMime(mime) || 'bin'}`;
+        textSegments.push(
+            `\n[attached file: ${displayName}]\n\`\`\`${lang}\n${asText}\n\`\`\`\n`
+        );
+    }
+
+    return {
+        text: textSegments.join('\n'),
+        attachments,
+    };
+}
+
+module.exports = {
+    classifyParts,
+    AttachmentBudgetError,
+    MODE,
+};

--- a/src/claude.js
+++ b/src/claude.js
@@ -63,12 +63,7 @@ function resolveModel(modelId) {
 /** Context window size per model, derived from the resolved CLI model name. */
 function getContextWindow(modelId) {
     const resolved = resolveModel(modelId);
-    return (
-        modelId === 'claude-opus-4-7' ||
-        modelId === 'claude-opus-4-6' ||
-        modelId === 'claude-sonnet-4-6' ||
-        resolved.includes('[1m]')
-    ) ? 1_000_000 : 200_000;
+    return resolved.includes('[1m]') ? 1_000_000 : 200_000;
 }
 
 /**
@@ -107,6 +102,7 @@ function mapEffort(reasoningEffort) {
 const SCRUB_PATTERNS = [
     /\b[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+\b/g,   // SCREAMING_SNAKE_CASE (2+ segments)
     /\[\[\s*(\w+)\s*\]\]/g,                    // [[bracket_tags]]
+    /\bsessions_[a-z_]+\b/g,                   // sessions_* tool names
 ];
 
 const SCRUB_WHITELIST = new Set([
@@ -301,6 +297,7 @@ function runClaude(systemPrompt, promptText, modelId, onChunk, signal, reasoning
         let fullText = '';
         let fullUsage = { input_tokens: 0, output_tokens: 0 };
         let buffer = '';
+        let stderrText = '';
 
         proc.stdout.on('data', (chunk) => {
             resetIdle(); // Claude is alive — reset idle timer
@@ -323,7 +320,10 @@ function runClaude(systemPrompt, promptText, modelId, onChunk, signal, reasoning
 
         proc.stderr.on('data', (data) => {
             const msg = data.toString().trim();
-            if (msg) console.error(`[claude stderr] ${msg}`);
+            if (msg) {
+                stderrText += (stderrText ? '\n' : '') + msg;
+                console.error(`[claude stderr] ${msg}`);
+            }
         });
 
         proc.on('close', (code) => {
@@ -340,8 +340,13 @@ function runClaude(systemPrompt, promptText, modelId, onChunk, signal, reasoning
                 } catch {}
             }
 
-            if (code !== 0 && !fullText) {
-                reject(new Error(`Claude exited with code ${code}`));
+            const text = typeof fullText === 'string' ? fullText.trim() : '';
+            const detail = stderrText ? `: ${stderrText.split('\n').slice(-3).join(' | ')}` : '';
+
+            if (code !== 0 && !text) {
+                reject(new Error(`Claude exited with code ${code}${detail}`));
+            } else if (!text && (fullUsage.output_tokens ?? 0) === 0) {
+                reject(new Error(`Claude returned empty response${detail}`));
             } else {
                 // Inbound: restore aliases → original tokens
                 if (fullText) {

--- a/src/claude.js
+++ b/src/claude.js
@@ -199,7 +199,7 @@ function restoreInbound(text, alias, aliasLower, sessionId) {
     return text;
 }
 
-function runClaude(systemPrompt, promptText, modelId, onChunk, signal, reasoningEffort, sessionId, isResume) {
+function runClaude(systemPrompt, promptText, modelId, onChunk, signal, reasoningEffort, sessionId, isResume, attachmentBlocks) {
     // Stable alias per session — see getSessionAlias() above.
     const { alias, aliasLower } = getSessionAlias(sessionId);
     if (systemPrompt) {
@@ -212,12 +212,19 @@ function runClaude(systemPrompt, promptText, modelId, onChunk, signal, reasoning
     return new Promise((resolve, reject) => {
         const model = resolveModel(modelId);
 
+        // Stream-json input mode is required when we have attachment blocks
+        // (images/PDFs) — the CLI doesn't accept attachments in text mode.
+        const hasAttachments = Array.isArray(attachmentBlocks) && attachmentBlocks.length > 0;
+
         const args = [
             '--print',
             '--dangerously-skip-permissions',
             '--output-format', 'stream-json',
             '--verbose',
         ];
+        if (hasAttachments) {
+            args.push('--input-format', 'stream-json');
+        }
 
         // Always pass --model (not persisted in session)
         args.push('--model', model);
@@ -291,7 +298,29 @@ function runClaude(systemPrompt, promptText, modelId, onChunk, signal, reasoning
         const hardTimer = setTimeout(() => kill(`Hard timeout (${MAX_RUN_MS / 60000}min)`), MAX_RUN_MS);
 
         // Write conversation to stdin
-        proc.stdin.write(promptText);
+        if (hasAttachments) {
+            // Stream-json input: one user message with text + image/document blocks.
+            // The prior conversation transcript is embedded as a single big text
+            // block; the attachments come last so they're clearly the "current"
+            // input the user is asking about.
+            const contentBlocks = [];
+            if (promptText) {
+                contentBlocks.push({ type: 'text', text: promptText });
+            }
+            for (const b of attachmentBlocks) {
+                contentBlocks.push(b);
+            }
+            const streamMsg = {
+                type: 'user',
+                message: {
+                    role: 'user',
+                    content: contentBlocks,
+                },
+            };
+            proc.stdin.write(JSON.stringify(streamMsg) + '\n');
+        } else {
+            proc.stdin.write(promptText);
+        }
         proc.stdin.end();
 
         let fullText = '';

--- a/src/claude.js
+++ b/src/claude.js
@@ -103,7 +103,6 @@ function mapEffort(reasoningEffort) {
 const SCRUB_PATTERNS = [
     /\b[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+\b/g,   // SCREAMING_SNAKE_CASE (2+ segments)
     /\[\[\s*(\w+)\s*\]\]/g,                    // [[bracket_tags]]
-    /\bsessions_[a-z_]+\b/g,                   // sessions_* tool names
 ];
 
 const SCRUB_WHITELIST = new Set([
@@ -236,8 +235,11 @@ function runClaude(systemPrompt, promptText, modelId, onChunk, signal, reasoning
             args.push('--system-prompt', systemPrompt);
         }
 
-        // Always disable native tools (CLI flag, not session property)
+        // Always disable Claude built-in tools. Also force MCP isolation so
+        // ambient local MCP servers cannot leak into the bridge session and
+        // bypass OpenClaw's tool loop.
         args.push('--tools', '');
+        args.push('--strict-mcp-config');
 
         // Map OC reasoning_effort → Claude CLI --effort
         const effort = mapEffort(reasoningEffort);

--- a/src/claude.js
+++ b/src/claude.js
@@ -55,6 +55,7 @@ setInterval(() => {
 function resolveModel(modelId) {
     const modelMap = {
         'claude-opus-latest':    process.env.OPUS_MODEL   || 'opus',
+        'claude-opus-4-7':       process.env.OPUS_47_MODEL || 'claude-opus-4-7',
         'claude-sonnet-latest':  process.env.SONNET_MODEL || 'sonnet',
         'claude-haiku-latest':   process.env.HAIKU_MODEL  || 'haiku',
     };

--- a/src/claude.js
+++ b/src/claude.js
@@ -48,16 +48,14 @@ setInterval(() => {
 
 /**
  * Map OpenClaw model IDs to Claude CLI model names.
- * Uses CLI aliases (opus/sonnet/haiku) by default so we always get the latest
- * model without code changes.  Override via env vars in .env if needed,
- * e.g. OPUS_MODEL=opus[1m] when 1M context becomes available.
+ * Exposes explicit Anthropic-style model ids.
  */
 function resolveModel(modelId) {
     const modelMap = {
-        'claude-opus-latest':    process.env.OPUS_MODEL   || 'opus',
-        'claude-opus-4-7':       process.env.OPUS_47_MODEL || 'claude-opus-4-7',
-        'claude-sonnet-latest':  process.env.SONNET_MODEL || 'sonnet',
-        'claude-haiku-latest':   process.env.HAIKU_MODEL  || 'haiku',
+        'claude-opus-4-7':      process.env.OPUS_47_MODEL || 'claude-opus-4-7',
+        'claude-opus-4-6':      process.env.OPUS_MODEL || 'claude-opus-4-6',
+        'claude-sonnet-4-6':    process.env.SONNET_MODEL || 'claude-sonnet-4-6',
+        'claude-haiku-4-5':     process.env.HAIKU_MODEL || 'claude-haiku-4-5',
     };
     return modelMap[modelId] || modelId;
 }
@@ -65,7 +63,12 @@ function resolveModel(modelId) {
 /** Context window size per model, derived from the resolved CLI model name. */
 function getContextWindow(modelId) {
     const resolved = resolveModel(modelId);
-    return resolved.includes('[1m]') ? 1_000_000 : 200_000;
+    return (
+        modelId === 'claude-opus-4-7' ||
+        modelId === 'claude-opus-4-6' ||
+        modelId === 'claude-sonnet-4-6' ||
+        resolved.includes('[1m]')
+    ) ? 1_000_000 : 200_000;
 }
 
 /**

--- a/src/claude.js
+++ b/src/claude.js
@@ -2,6 +2,7 @@
 
 const { spawn } = require('child_process');
 const crypto = require('crypto');
+const { NOSCRUB_OPEN, NOSCRUB_CLOSE } = require('./convert');
 
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
 
@@ -199,15 +200,60 @@ function restoreInbound(text, alias, aliasLower, sessionId) {
     return text;
 }
 
+
+/**
+ * Apply brand substitution (OpenClaw -> alias, openclaw -> aliasLower) to all
+ * regions of `text` EXCEPT those wrapped in NOSCRUB_OPEN/NOSCRUB_CLOSE
+ * sentinels. Sentinels are stripped from the returned string.
+ *
+ * Used so tool_call JSON args and tool_result payloads — which contain
+ * literal on-disk data the orchestrator owns (file paths, command output,
+ * identifiers) — pass through to Claude verbatim while surrounding
+ * user/assistant prose still gets brand-substituted.
+ *
+ * Preserves the prior `promptText` scope: brand-only, no pattern token
+ * scrubbing. systemPrompt continues to go through the heavier scrubOutbound.
+ */
+function brandSubstituteWithSkipRegions(text, alias, aliasLower) {
+    if (!text) return text;
+    const apply = (chunk) => chunk
+        .replace(/OpenClaw/g, alias)
+        .replace(/openclaw/g, aliasLower);
+    if (!text.includes(NOSCRUB_OPEN)) {
+        return apply(text);
+    }
+    const out = [];
+    let i = 0;
+    while (i < text.length) {
+        const openIdx = text.indexOf(NOSCRUB_OPEN, i);
+        if (openIdx === -1) {
+            out.push(apply(text.slice(i)));
+            break;
+        }
+        if (openIdx > i) {
+            out.push(apply(text.slice(i, openIdx)));
+        }
+        const closeIdx = text.indexOf(NOSCRUB_CLOSE, openIdx + NOSCRUB_OPEN.length);
+        if (closeIdx === -1) {
+            // Malformed sentinel pair — fail safe by brand-substituting the
+            // rest with the open marker stripped, so brand strings never leak
+            // unsubstituted when the structure is broken.
+            out.push(apply(text.slice(openIdx + NOSCRUB_OPEN.length)));
+            break;
+        }
+        out.push(text.slice(openIdx + NOSCRUB_OPEN.length, closeIdx));
+        i = closeIdx + NOSCRUB_CLOSE.length;
+    }
+    return out.join('');
+}
+
 function runClaude(systemPrompt, promptText, modelId, onChunk, signal, reasoningEffort, sessionId, isResume, attachmentBlocks) {
     // Stable alias per session — see getSessionAlias() above.
     const { alias, aliasLower } = getSessionAlias(sessionId);
     if (systemPrompt) {
         systemPrompt = scrubOutbound(systemPrompt, alias, aliasLower, sessionId);
     }
-    promptText = promptText
-        .replace(/OpenClaw/g, alias)
-        .replace(/openclaw/g, aliasLower);
+    promptText = brandSubstituteWithSkipRegions(promptText, alias, aliasLower);
 
     return new Promise((resolve, reject) => {
         const model = resolveModel(modelId);

--- a/src/convert.js
+++ b/src/convert.js
@@ -1,29 +1,64 @@
 'use strict';
 
+const { classifyParts, AttachmentBudgetError } = require('./attachments');
+
 /**
- * Convert an OpenAI messages array into:
- *   - systemPrompt: string (from developer/system roles)
- *   - promptText: string (conversation + user message for stdin)
+ * Convert an OpenAI messages array into the bridge's internal shape.
+ *
+ * Returns:
+ *   {
+ *     systemPrompt: string,
+ *     promptText: string,        // text-mode stdin
+ *     attachmentBlocks: array,   // Anthropic content blocks for the FINAL user
+ *                                // turn (image, document); empty if no
+ *                                // attachments present in the latest user turn
+ *   }
+ *
+ * The bridge sends `promptText` via plain stdin when attachmentBlocks is empty.
+ * Otherwise it builds a stream-json input where the final user message has the
+ * attachment blocks appended, and the prior conversation is rendered as text
+ * via the standard <previous_response>/<tool_result> wrapping.
+ *
+ * Attachment behavior is controlled by OPENCLAW_BRIDGE_ATTACHMENT_MODE
+ * (passthrough = default, describe = drop non-text parts).
  *
  * Handles the full OpenAI message format including tool_calls and tool results
  * so Claude can see the complete conversation history.
  */
-function convertMessages(messages) {
+function convertMessages(messages, opts = {}) {
+    const { turnId = `t-${Date.now().toString(36)}` } = opts;
+
     const systemParts = [];
     const conversationParts = [];
+    let lastUserAttachments = [];
 
-    for (const msg of messages) {
+    // Locate the index of the last user message so we know where to attach
+    // multimodal blocks. Attachments on earlier user turns get inlined as
+    // text-mode descriptions (we don't try to interleave images across turns
+    // because the CLI's session resume needs a single coherent transcript).
+    let lastUserIdx = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i].role === 'user') { lastUserIdx = i; break; }
+    }
+
+    for (let i = 0; i < messages.length; i++) {
+        const msg = messages[i];
         const role = msg.role;
-        const content = extractContent(msg.content);
+        const isLastUser = (i === lastUserIdx);
 
         if (role === 'developer' || role === 'system') {
-            systemParts.push(content);
+            systemParts.push(_classifyToText(msg.content, turnId));
         } else if (role === 'user') {
-            conversationParts.push(`User: ${content}`);
+            const { text, attachments } = _classify(msg.content, turnId);
+            if (isLastUser && attachments.length > 0) {
+                lastUserAttachments = attachments;
+            }
+            conversationParts.push(`User: ${text}`);
         } else if (role === 'assistant') {
             // Include both text content and any tool_calls from history
+            const text = _classifyToText(msg.content, turnId);
             const parts = [];
-            if (content) parts.push(content);
+            if (text) parts.push(text);
 
             // Include tool_calls so Claude knows what was previously requested
             if (Array.isArray(msg.tool_calls)) {
@@ -40,8 +75,9 @@ function convertMessages(messages) {
             // Tool results from OC's execution — include so Claude can use them
             const toolName = msg.name || '';
             const toolId = msg.tool_call_id || '';
-            if (content) {
-                conversationParts.push(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${content}\n</tool_result>`);
+            const text = _classifyToText(msg.content, turnId);
+            if (text) {
+                conversationParts.push(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${text}\n</tool_result>`);
             }
         }
     }
@@ -49,11 +85,31 @@ function convertMessages(messages) {
     return {
         systemPrompt: systemParts.join('\n\n'),
         promptText: conversationParts.join('\n\n'),
+        attachmentBlocks: lastUserAttachments,
     };
+}
+
+function _classify(content, turnId) {
+    try {
+        return classifyParts(content, turnId);
+    } catch (err) {
+        if (err instanceof AttachmentBudgetError) {
+            console.warn(`[convert.js] ${err.message}`);
+            return { text: '[attachments dropped: budget]', attachments: [] };
+        }
+        console.warn(`[convert.js] classify failed: ${err.message}`);
+        return { text: String(content || ''), attachments: [] };
+    }
+}
+
+function _classifyToText(content, turnId) {
+    const { text } = _classify(content, turnId);
+    return text;
 }
 
 /**
  * Extract plain text from a content field (string or array of parts).
+ * Kept for backward compatibility with any direct callers.
  */
 function extractContent(content) {
     if (typeof content === 'string') return content;
@@ -69,10 +125,13 @@ function extractContent(content) {
 
 /**
  * Extract only the new messages after the last assistant tool_calls message.
- * Used for --resume mode (tool loop) to avoid re-sending the full conversation history.
- * Returns formatted text string, or null if no tool_calls found.
+ * Used for --resume mode (tool loop) to avoid re-sending the full history.
+ *
+ * Returns {newText, attachmentBlocks} or null if no tool_calls found.
  */
-function extractNewMessages(messages, { toolResultCap = 15000 } = {}) {
+function extractNewMessages(messages, opts = {}) {
+    const { toolResultCap = 15000, turnId = `t-${Date.now().toString(36)}` } = opts;
+
     // Find the last assistant message with tool_calls (from the tail)
     let lastToolCallIdx = -1;
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -87,37 +146,48 @@ function extractNewMessages(messages, { toolResultCap = 15000 } = {}) {
     // the tool loop is over. Return null to fall through to extractNewUserMessages().
     for (let i = lastToolCallIdx + 1; i < messages.length; i++) {
         if (messages[i].role === 'assistant') {
-            return null;  // Tool loop ended — use extractNewUserMessages() instead
+            return null;
         }
     }
 
     // Only take messages after the last assistant tool_calls
     const newMessages = messages.slice(lastToolCallIdx + 1);
+    let lastUserIdx = -1;
+    for (let i = newMessages.length - 1; i >= 0; i--) {
+        if (newMessages[i].role === 'user') { lastUserIdx = i; break; }
+    }
+
     const parts = [];
-    for (const msg of newMessages) {
+    let attachmentBlocks = [];
+
+    for (let i = 0; i < newMessages.length; i++) {
+        const msg = newMessages[i];
         if (msg.role === 'tool') {
             const toolName = msg.name || '';
             const toolId = msg.tool_call_id || '';
-            let content = extractContent(msg.content);
-            if (content) {
-                if (content.length > toolResultCap) {
-                    content = content.slice(0, toolResultCap) + '\n[... truncated]';
-                }
-                parts.push(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${content}\n</tool_result>`);
+            let { text } = _classify(msg.content, turnId);
+            if (text) {
+                if (text.length > toolResultCap) text = text.slice(0, toolResultCap) + '\n[... truncated]';
+                parts.push(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${text}\n</tool_result>`);
             }
         } else if (msg.role === 'user') {
-            parts.push(`User: ${extractContent(msg.content)}`);
+            const { text, attachments } = _classify(msg.content, turnId);
+            if (i === lastUserIdx && attachments.length > 0) attachmentBlocks = attachments;
+            parts.push(`User: ${text}`);
         }
     }
-    return parts.join('\n\n');
+    return { newText: parts.join('\n\n'), attachmentBlocks };
 }
 
 /**
  * Extract messages after the last assistant message (regardless of tool_calls).
  * Used for --resume mode when the conversation has no tool_calls (simple continuation).
- * Returns formatted text string, or null if nothing new found.
+ *
+ * Returns {newText, attachmentBlocks} or null if nothing new found.
  */
-function extractNewUserMessages(messages, { toolResultCap = 15000 } = {}) {
+function extractNewUserMessages(messages, opts = {}) {
+    const { toolResultCap = 15000, turnId = `t-${Date.now().toString(36)}` } = opts;
+
     // Find the last assistant message (from the tail)
     let lastAssistantIdx = -1;
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -132,29 +202,37 @@ function extractNewUserMessages(messages, { toolResultCap = 15000 } = {}) {
     const newMessages = messages.slice(lastAssistantIdx + 1);
     if (newMessages.length === 0) return null;
 
+    let lastUserIdx = -1;
+    for (let i = newMessages.length - 1; i >= 0; i--) {
+        if (newMessages[i].role === 'user') { lastUserIdx = i; break; }
+    }
+
     const parts = [];
-    for (const msg of newMessages) {
+    let attachmentBlocks = [];
+
+    for (let i = 0; i < newMessages.length; i++) {
+        const msg = newMessages[i];
         if (msg.role === 'user') {
-            const content = extractContent(msg.content);
-            if (content) parts.push(content);
+            const { text, attachments } = _classify(msg.content, turnId);
+            if (i === lastUserIdx && attachments.length > 0) attachmentBlocks = attachments;
+            if (text) parts.push(text);
         } else if (msg.role === 'tool') {
             const toolName = msg.name || '';
             const toolId = msg.tool_call_id || '';
-            let content = extractContent(msg.content);
-            if (content) {
-                if (content.length > toolResultCap) {
-                    content = content.slice(0, toolResultCap) + '\n[... truncated]';
-                }
-                parts.push(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${content}\n</tool_result>`);
+            let { text } = _classify(msg.content, turnId);
+            if (text) {
+                if (text.length > toolResultCap) text = text.slice(0, toolResultCap) + '\n[... truncated]';
+                parts.push(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${text}\n</tool_result>`);
             }
         }
     }
-    return parts.length > 0 ? parts.join('\n\n') : null;
+    return parts.length > 0 ? { newText: parts.join('\n\n'), attachmentBlocks } : null;
 }
 
 /**
  * Compact version of convertMessages for context refresh.
  * Truncates assistant text and tool results to reduce prompt size.
+ * Same return shape as convertMessages.
  */
 function convertMessagesCompact(messages, opts = {}) {
     const {
@@ -162,10 +240,17 @@ function convertMessagesCompact(messages, opts = {}) {
         recentToolCap = 2000,
         oldToolCap = 500,
         recentTurns = 10,
+        turnId = `t-${Date.now().toString(36)}`,
     } = opts;
 
     const systemParts = [];
     const conversationParts = [];
+    let lastUserAttachments = [];
+
+    let lastUserIdx = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i].role === 'user') { lastUserIdx = i; break; }
+    }
 
     // Count user turns to determine recent vs old
     let userTurnCount = 0;
@@ -175,22 +260,25 @@ function convertMessagesCompact(messages, opts = {}) {
     const recentCutoff = Math.max(0, userTurnCount - recentTurns);
 
     let currentUserTurn = 0;
-    for (const msg of messages) {
+    for (let i = 0; i < messages.length; i++) {
+        const msg = messages[i];
         const role = msg.role;
-        const content = extractContent(msg.content);
 
         if (role === 'developer' || role === 'system') {
-            systemParts.push(content);
+            systemParts.push(_classifyToText(msg.content, turnId));
         } else if (role === 'user') {
             currentUserTurn++;
-            conversationParts.push(`User: ${content}`);
+            const { text, attachments } = _classify(msg.content, turnId);
+            if (i === lastUserIdx && attachments.length > 0) lastUserAttachments = attachments;
+            conversationParts.push(`User: ${text}`);
         } else if (role === 'assistant') {
+            const text = _classifyToText(msg.content, turnId);
             const parts = [];
-            if (content) {
-                if (content.length > assistantCap) {
-                    parts.push(content.slice(0, assistantCap) + '\n[... truncated]');
+            if (text) {
+                if (text.length > assistantCap) {
+                    parts.push(text.slice(0, assistantCap) + '\n[... truncated]');
                 } else {
-                    parts.push(content);
+                    parts.push(text);
                 }
             }
             if (Array.isArray(msg.tool_calls)) {
@@ -205,9 +293,10 @@ function convertMessagesCompact(messages, opts = {}) {
         } else if (role === 'tool') {
             const toolName = msg.name || '';
             const toolId = msg.tool_call_id || '';
-            if (content) {
+            const { text } = _classify(msg.content, turnId);
+            if (text) {
                 const cap = currentUserTurn >= recentCutoff ? recentToolCap : oldToolCap;
-                const truncated = content.length > cap ? content.slice(0, cap) + '\n[... truncated]' : content;
+                const truncated = text.length > cap ? text.slice(0, cap) + '\n[... truncated]' : text;
                 conversationParts.push(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${truncated}\n</tool_result>`);
             }
         }
@@ -216,7 +305,8 @@ function convertMessagesCompact(messages, opts = {}) {
     return {
         systemPrompt: systemParts.join('\n\n'),
         promptText: conversationParts.join('\n\n'),
+        attachmentBlocks: lastUserAttachments,
     };
 }
 
-module.exports = { convertMessages, convertMessagesCompact, extractNewMessages, extractNewUserMessages };
+module.exports = { convertMessages, convertMessagesCompact, extractNewMessages, extractNewUserMessages, extractContent };

--- a/src/convert.js
+++ b/src/convert.js
@@ -2,6 +2,20 @@
 
 const { classifyParts, AttachmentBudgetError } = require('./attachments');
 
+// Sentinel markers that delimit regions of promptText which must NOT be scrubbed.
+// Tool-call JSON arguments and tool-result payloads contain literal data (file
+// paths, command output, identifiers) that the orchestrator owns — scrubbing
+// them corrupts on-disk reality. We wrap those regions on the way out and strip
+// the markers in claude.js after a scope-aware scrub pass.
+// Markers are constructed from char codes so they themselves can never be
+// substituted by the scrubber.
+const NOSCRUB_OPEN  = String.fromCharCode(0x1E) + 'NOSCRUB' + String.fromCharCode(0x1F);
+const NOSCRUB_CLOSE = String.fromCharCode(0x1F) + 'NOSCRUB' + String.fromCharCode(0x1E);
+function noscrub(text) {
+    return NOSCRUB_OPEN + text + NOSCRUB_CLOSE;
+}
+
+
 /**
  * Convert an OpenAI messages array into the bridge's internal shape.
  *
@@ -64,7 +78,7 @@ function convertMessages(messages, opts = {}) {
             if (Array.isArray(msg.tool_calls)) {
                 for (const tc of msg.tool_calls) {
                     const fn = tc.function || {};
-                    parts.push(`<tool_call>\n{"name": "${fn.name}", "arguments": ${fn.arguments || '{}'}}\n</tool_call>`);
+                    parts.push(noscrub(`<tool_call>\n{"name": "${fn.name}", "arguments": ${fn.arguments || '{}'}}\n</tool_call>`));
                 }
             }
 
@@ -77,7 +91,7 @@ function convertMessages(messages, opts = {}) {
             const toolId = msg.tool_call_id || '';
             const text = _classifyToText(msg.content, turnId);
             if (text) {
-                conversationParts.push(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${text}\n</tool_result>`);
+                conversationParts.push(noscrub(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${text}\n</tool_result>`));
             }
         }
     }
@@ -168,7 +182,7 @@ function extractNewMessages(messages, opts = {}) {
             let { text } = _classify(msg.content, turnId);
             if (text) {
                 if (text.length > toolResultCap) text = text.slice(0, toolResultCap) + '\n[... truncated]';
-                parts.push(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${text}\n</tool_result>`);
+                parts.push(noscrub(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${text}\n</tool_result>`));
             }
         } else if (msg.role === 'user') {
             const { text, attachments } = _classify(msg.content, turnId);
@@ -222,7 +236,7 @@ function extractNewUserMessages(messages, opts = {}) {
             let { text } = _classify(msg.content, turnId);
             if (text) {
                 if (text.length > toolResultCap) text = text.slice(0, toolResultCap) + '\n[... truncated]';
-                parts.push(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${text}\n</tool_result>`);
+                parts.push(noscrub(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${text}\n</tool_result>`));
             }
         }
     }
@@ -284,7 +298,7 @@ function convertMessagesCompact(messages, opts = {}) {
             if (Array.isArray(msg.tool_calls)) {
                 for (const tc of msg.tool_calls) {
                     const fn = tc.function || {};
-                    parts.push(`<tool_call>\n{"name": "${fn.name}", "arguments": ${fn.arguments || '{}'}}\n</tool_call>`);
+                    parts.push(noscrub(`<tool_call>\n{"name": "${fn.name}", "arguments": ${fn.arguments || '{}'}}\n</tool_call>`));
                 }
             }
             if (parts.length > 0) {
@@ -297,7 +311,7 @@ function convertMessagesCompact(messages, opts = {}) {
             if (text) {
                 const cap = currentUserTurn >= recentCutoff ? recentToolCap : oldToolCap;
                 const truncated = text.length > cap ? text.slice(0, cap) + '\n[... truncated]' : text;
-                conversationParts.push(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${truncated}\n</tool_result>`);
+                conversationParts.push(noscrub(`<tool_result name="${toolName}" tool_call_id="${toolId}">\n${truncated}\n</tool_result>`));
             }
         }
     }
@@ -309,4 +323,4 @@ function convertMessagesCompact(messages, opts = {}) {
     };
 }
 
-module.exports = { convertMessages, convertMessagesCompact, extractNewMessages, extractNewUserMessages, extractContent };
+module.exports = { convertMessages, convertMessagesCompact, extractNewMessages, extractNewUserMessages, extractContent, NOSCRUB_OPEN, NOSCRUB_CLOSE };

--- a/src/server.js
+++ b/src/server.js
@@ -482,29 +482,8 @@ app.post('/v1/chat/completions', async (req, res) => {
             });
         }
 
-        // OC /new startup interception: first request of /new has no metadata, just marker + startup prompt.
-        // Skip creating a CLI session — the real request (with metadata) follows immediately after.
-        if (messages.length <= 4 && !extractConversationLabel(messages) &&
-            messages.some(m => {
-                const c = typeof m.content === 'string' ? m.content : Array.isArray(m.content) ? m.content.filter(p => p.type === 'text').map(p => p.text).join('') : '';
-                return c.includes('New session started');
-            })) {
-            const nsAgent = extractAgentName(messages);
-            logEntry.agent = nsAgent || null;
-            console.log(`[${requestId}] OC /new startup intercepted (${messages.length} msgs, agent="${nsAgent}"), returning NO_REPLY`);
-            logEntry.status = 'ok';
-            logEntry.resumeMethod = 'newstart';
-            logEntry.promptLen = 0;
-            logEntry.durationMs = Date.now() - startTime;
-            return res.json({
-                id: `chatcmpl-${requestId}`,
-                object: 'chat.completion',
-                created: Math.floor(Date.now() / 1000),
-                model,
-                choices: [{ index: 0, message: { role: 'assistant', content: 'NO_REPLY' }, finish_reason: 'stop' }],
-                usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
-            });
-        }
+        // OC /new startup requests now surface user-visible failures if we return a synthetic
+        // empty stop payload here. Let them flow through to Claude so Forge gets a real first turn.
 
         // --- Session reuse detection ---
         gcMemory();

--- a/src/server.js
+++ b/src/server.js
@@ -354,10 +354,10 @@ app.get('/v1/models', (req, res) => {
     res.json({
         object: 'list',
         data: [
-            { id: 'claude-opus-latest',   object: 'model', created: 1700000000, owned_by: 'anthropic' },
-            { id: 'claude-opus-4-7',      object: 'model', created: 1700000000, owned_by: 'anthropic' },
-            { id: 'claude-sonnet-latest', object: 'model', created: 1700000000, owned_by: 'anthropic' },
-            { id: 'claude-haiku-latest',  object: 'model', created: 1700000000, owned_by: 'anthropic' },
+            { id: 'claude-opus-4-7',   object: 'model', created: 1700000000, owned_by: 'anthropic' },
+            { id: 'claude-opus-4-6',   object: 'model', created: 1700000000, owned_by: 'anthropic' },
+            { id: 'claude-sonnet-4-6', object: 'model', created: 1700000000, owned_by: 'anthropic' },
+            { id: 'claude-haiku-4-5',  object: 'model', created: 1700000000, owned_by: 'anthropic' },
         ],
     });
 });
@@ -404,7 +404,7 @@ app.post('/v1/chat/completions', async (req, res) => {
     pushLog(logEntry); // appear in dashboard immediately as 'pending'
 
     try {
-        const { messages = [], tools = [], model = 'claude-opus-latest', stream = true, reasoning_effort } = req.body;
+        const { messages = [], tools = [], model = 'claude-opus-4-7', stream = true, reasoning_effort } = req.body;
         stats.lastModel = model;
         logEntry.model = model;
         logEntry.contextWindow = getContextWindow(model);
@@ -972,10 +972,10 @@ statusApp.get('/status', (req, res) => {
             age: Math.floor((Date.now() - val.createdAt) / 1000),
         })),
         contextWindows: {
-            'claude-opus-latest': getContextWindow('claude-opus-latest'),
             'claude-opus-4-7': getContextWindow('claude-opus-4-7'),
-            'claude-sonnet-latest': getContextWindow('claude-sonnet-latest'),
-            'claude-haiku-latest': getContextWindow('claude-haiku-latest'),
+            'claude-opus-4-6': getContextWindow('claude-opus-4-6'),
+            'claude-sonnet-4-6': getContextWindow('claude-sonnet-4-6'),
+            'claude-haiku-4-5': getContextWindow('claude-haiku-4-5'),
         },
         activity: globalActivity.slice(-30),
         log: [...requestLog].reverse(),

--- a/src/server.js
+++ b/src/server.js
@@ -275,6 +275,60 @@ loadState();
 function parseToolCalls(text) {
     const regex = /<tool_call>\s*([\s\S]*?)\s*<\/tool_call>/g;
     const calls = [];
+
+    function normalizeJsonish(text) {
+        let out = '';
+        let inString = false;
+        let escape = false;
+        for (const ch of text) {
+            if (escape) {
+                out += ch;
+                escape = false;
+                continue;
+            }
+            if (ch === '\\') {
+                out += ch;
+                escape = true;
+                continue;
+            }
+            if (ch === '"') {
+                out += ch;
+                inString = !inString;
+                continue;
+            }
+            if (inString) {
+                if (ch === '\n') {
+                    out += '\\n';
+                    continue;
+                }
+                if (ch === '\r') {
+                    out += '\\r';
+                    continue;
+                }
+                if (ch === '\t') {
+                    out += '\\t';
+                    continue;
+                }
+            }
+            out += ch;
+        }
+        return out;
+    }
+
+    function parseLooseJson(jsonText) {
+        try {
+            return { parsed: JSON.parse(jsonText), recovered: false };
+        } catch (firstErr) {
+            const normalized = normalizeJsonish(jsonText);
+            if (normalized !== jsonText) {
+                try {
+                    return { parsed: JSON.parse(normalized), recovered: true };
+                } catch {}
+            }
+            throw firstErr;
+        }
+    }
+
     let match;
     while ((match = regex.exec(text)) !== null) {
         const raw = (match[1] || '').trim();
@@ -286,10 +340,13 @@ function parseToolCalls(text) {
         }
         const jsonText = raw.slice(start, end + 1);
         try {
-            const parsed = JSON.parse(jsonText);
+            const { parsed, recovered } = parseLooseJson(jsonText);
             if (!parsed || typeof parsed.name !== 'string') {
                 console.error(`[parseToolCalls] Invalid tool_call payload: ${jsonText.slice(0, 300)}`);
                 continue;
+            }
+            if (recovered) {
+                console.warn(`[parseToolCalls] Recovered malformed tool_call JSON for ${parsed.name}`);
             }
             const args = (parsed.arguments && typeof parsed.arguments === 'object' && !Array.isArray(parsed.arguments))
                 ? parsed.arguments
@@ -304,22 +361,6 @@ function parseToolCalls(text) {
         }
     }
     return calls;
-}
-
-function getAvailableToolNames(tools) {
-    if (!Array.isArray(tools)) return [];
-    return tools.map(tool => tool?.function?.name || tool?.name).filter(Boolean);
-}
-
-function filterToolCalls(toolCalls, availableToolNames) {
-    const allowed = new Set(availableToolNames || []);
-    const valid = [];
-    const invalid = [];
-    for (const call of toolCalls || []) {
-        if (allowed.has(call.name)) valid.push(call);
-        else invalid.push(call);
-    }
-    return { valid, invalid };
 }
 
 /**
@@ -711,29 +752,47 @@ app.post('/v1/chat/completions', async (req, res) => {
         try {
             ({ text: finalText, usage: finalUsage } = await runClaude(combinedSystemPrompt, promptText, model, onChunk, ac.signal, reasoning_effort, sessionId, isResume));
         } catch (err) {
+            const errMessage = err?.message || 'Unknown Claude error';
+            const emptyCompletion = /empty response/i.test(errMessage);
+            const terminatedCompletion = /(^|\b)terminated(\b|$)/i.test(errMessage);
+            const retryableFreshFailure = emptyCompletion || terminatedCompletion;
+            const wasResume = isResume;
+
             // OC disconnected (timeout/restart) — not a CLI error, preserve session
-            if (isResume && err.message === 'Client disconnected') {
+            if (wasResume && errMessage === 'Client disconnected') {
                 console.log(`[${requestId}] OC disconnected, preserving session=${sessionId.slice(0, 8)}`);
                 logEntry.status = 'oc_disconnect';
-                logEntry.error = err.message;
+                logEntry.error = errMessage;
                 logEntry.durationMs = Date.now() - startTime;
                 return;
             }
-            // CLI failed (context overflow, crash, etc.) — retry with compact history
-            if (isResume) {
-                console.warn(`[${requestId}] CLI failed (${err.message}), retrying with compact refresh`);
-                pushActivity(requestId, `⚠ CLI failed, retrying with compact refresh`);
-                logEntry.activity.push(`⚠ CLI failed: ${err.message}`);
+
+            // Retry resume failures with compact refresh, and retry empty/terminated
+            // fresh-session failures once from a new Claude session.
+            if (wasResume || retryableFreshFailure) {
+                const retryLabel = wasResume ? 'compact refresh' : 'fresh session retry';
+                if (retryableFreshFailure) {
+                    const breadcrumb = terminatedCompletion ? '⚠ terminated_completion_retry' : '⚠ empty_completion_retry';
+                    const breadcrumbLog = terminatedCompletion ? 'terminated_completion_retry' : 'empty_completion_retry';
+                    console.warn(`[${requestId}] ${breadcrumbLog}: ${errMessage}`);
+                    pushActivity(requestId, breadcrumb);
+                    logEntry.activity.push(breadcrumb);
+                }
+                console.warn(`[${requestId}] Claude failed (${errMessage}), retrying with ${retryLabel}`);
+                pushActivity(requestId, `⚠ Claude failed, retrying with ${retryLabel}`);
+                logEntry.activity.push(`⚠ Claude failed: ${errMessage}`);
                 isResume = false;
                 sessionId = uuidv4();
-                logEntry.resumeMethod = 'refresh';
-                const compactResult = convertMessagesCompact(messages);
-                promptText = compactResult.promptText;
-                if (compactResult.systemPrompt) {
-                    combinedSystemPrompt = `${compactResult.systemPrompt}${toolInstructions}`;
+                logEntry.resumeMethod = wasResume ? 'refresh' : (terminatedCompletion ? 'retry_terminated' : 'retry_empty');
+                if (wasResume) {
+                    const compactResult = convertMessagesCompact(messages);
+                    promptText = compactResult.promptText;
+                    if (compactResult.systemPrompt) {
+                        combinedSystemPrompt = `${compactResult.systemPrompt}${toolInstructions}`;
+                    }
                 }
                 logEntry.promptLen = promptText.length;
-                console.log(`[${requestId}] Compact refresh: new session=${sessionId.slice(0, 8)} promptLen=${promptText.length}`);
+                console.log(`[${requestId}] Retry path: new session=${sessionId.slice(0, 8)} promptLen=${promptText.length}`);
                 try {
                     ({ text: finalText, usage: finalUsage } = await runClaude(combinedSystemPrompt, promptText, model, onChunk, ac.signal, reasoning_effort, sessionId, false));
                 } catch (retryErr) {
@@ -751,16 +810,16 @@ app.post('/v1/chat/completions', async (req, res) => {
                     return;
                 }
             } else {
-                console.error(`[${requestId}] Claude error: ${err.message}`);
+                console.error(`[${requestId}] Claude error: ${errMessage}`);
                 logEntry.status = 'error';
-                logEntry.error = err.message;
+                logEntry.error = errMessage;
                 if (isStream) {
-                    sendChunk(`\n\n[Error: ${err.message}]`);
+                    sendChunk(`\n\n[Error: ${errMessage}]`);
                     sendChunk('', 'stop');
                     res.write('data: [DONE]\n\n');
                     res.end();
                 } else {
-                    res.status(500).json({ error: { message: err.message, type: 'internal_error' } });
+                    res.status(500).json({ error: { message: errMessage, type: 'internal_error' } });
                 }
                 return;
             }
@@ -784,14 +843,7 @@ app.post('/v1/chat/completions', async (req, res) => {
         };
 
         // Parse <tool_call> blocks from Claude's response
-        const parsedToolCalls = parseToolCalls(finalText || '');
-        const availableToolNames = getAvailableToolNames(tools);
-        const { valid: toolCalls, invalid: invalidToolCalls } = filterToolCalls(parsedToolCalls, availableToolNames);
-        if (invalidToolCalls.length > 0) {
-            console.warn(`[${requestId}] filtered unavailable tool_calls: [${invalidToolCalls.map(tc => tc.name).join(', ')}]`);
-            pushActivity(requestId, `filtered unavailable tool_calls: [${invalidToolCalls.map(tc => tc.name).join(', ')}]`);
-            logEntry.activity.push(`filtered unavailable tool_calls: [${invalidToolCalls.map(tc => tc.name).join(', ')}]`);
-        }
+        const toolCalls = parseToolCalls(finalText || '');
 
         if (toolCalls.length > 0) {
             // Claude requested tools → return as OpenAI tool_calls for OC to execute

--- a/src/server.js
+++ b/src/server.js
@@ -355,6 +355,7 @@ app.get('/v1/models', (req, res) => {
         object: 'list',
         data: [
             { id: 'claude-opus-latest',   object: 'model', created: 1700000000, owned_by: 'anthropic' },
+            { id: 'claude-opus-4-7',      object: 'model', created: 1700000000, owned_by: 'anthropic' },
             { id: 'claude-sonnet-latest', object: 'model', created: 1700000000, owned_by: 'anthropic' },
             { id: 'claude-haiku-latest',  object: 'model', created: 1700000000, owned_by: 'anthropic' },
         ],
@@ -972,6 +973,7 @@ statusApp.get('/status', (req, res) => {
         })),
         contextWindows: {
             'claude-opus-latest': getContextWindow('claude-opus-latest'),
+            'claude-opus-4-7': getContextWindow('claude-opus-4-7'),
             'claude-sonnet-latest': getContextWindow('claude-sonnet-latest'),
             'claude-haiku-latest': getContextWindow('claude-haiku-latest'),
         },

--- a/src/server.js
+++ b/src/server.js
@@ -208,6 +208,34 @@ function extractAgentName(messages) {
     return null;
 }
 
+function messageText(msg) {
+    if (!msg) return '';
+    if (typeof msg.content === 'string') return msg.content;
+    if (Array.isArray(msg.content)) {
+        return msg.content
+            .filter(p => p && (p.type === 'text' || typeof p.text === 'string'))
+            .map(p => p.text || '')
+            .join('\n');
+    }
+    return '';
+}
+
+/**
+ * OpenClaw sometimes asks the configured model for a short session filename slug.
+ * That request can include Discord metadata and tools, so if it is proxied into a
+ * per-channel Claude CLI session it poisons the channel: future real prompts resume
+ * a title-generation conversation and Claude replies with the slug forever.
+ * Intercept it before session routing and do not store channelMap/responseMap state.
+ */
+function isSessionTitleSlugRequest(messages) {
+    return messages.some((msg) => {
+        if (msg.role !== 'user') return false;
+        const text = messageText(msg).trim();
+        return /^(?:User:\s*)?Based on this conversation, generate a short 1-2 word filename slug\b/i.test(text)
+            || /generate a short 1-2 word filename slug \(lowercase, hyphen-separated, no file extension\)/i.test(text);
+    });
+}
+
 /**
  * Detect if this is a new OC session (has "✅ New session started" marker
  * as the FIRST assistant/previous_response content, with no other assistant messages we recognise).
@@ -341,6 +369,24 @@ app.post('/v1/chat/completions', async (req, res) => {
         logEntry.effort = reasoning_effort || null;
         logEntry.thinking = !!reasoning_effort;
         if (reasoning_effort) console.log(`[${requestId}] reasoning_effort=${reasoning_effort}`);
+
+        if (isSessionTitleSlugRequest(messages)) {
+            const promptLen = messages.reduce((s, m) => s + messageText(m).length, 0);
+            console.warn(`[${requestId}] SESSION TITLE intercepted: tools=${tools.length} promptLen≈${promptLen}, returning NO_REPLY without session routing`);
+            logEntry.status = 'ok';
+            logEntry.resumeMethod = 'session_title_intercept';
+            logEntry.promptLen = promptLen;
+            logEntry.durationMs = Date.now() - startTime;
+            pushActivity(requestId, '🏷️ session title intercepted');
+            return res.json({
+                id: `chatcmpl-${requestId}`,
+                object: 'chat.completion',
+                created: Math.floor(Date.now() / 1000),
+                model,
+                choices: [{ index: 0, message: { role: 'assistant', content: 'NO_REPLY' }, finish_reason: 'stop' }],
+                usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+            });
+        }
 
         const allowedToolNames = new Set(tools.map(t => t.function?.name || t.name).filter(Boolean));
         if (tools.length > 0) {

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,7 @@ const { v4: uuidv4 } = require('uuid');
 const { convertMessages, convertMessagesCompact, extractNewMessages, extractNewUserMessages } = require('./convert');
 const { buildToolInstructions } = require('./tools');
 const { runClaude, getContextWindow, clearSessionAlias } = require('./claude');
+const { cleanResponseText, parseToolCallsDetailed } = require('./tool-parser');
 
 // --- Session cleanup ---
 // Claude CLI subprocess runs with cwd=/tmp. On macOS /tmp → /private/tmp,
@@ -268,120 +269,7 @@ function pushActivity(requestId, msg) {
 // Load persisted state (channelMap, responseMap, requestLog, stats, globalActivity)
 loadState();
 
-/**
- * Parse <tool_call> blocks from Claude's response text.
- * Returns array of { id, name, arguments } or empty array.
- */
-function parseToolCalls(text) {
-    const regex = /<tool_call>\s*([\s\S]*?)\s*<\/tool_call>/g;
-    const calls = [];
-
-    function normalizeJsonish(text) {
-        let out = '';
-        let inString = false;
-        let escape = false;
-        for (const ch of text) {
-            if (escape) {
-                out += ch;
-                escape = false;
-                continue;
-            }
-            if (ch === '\\') {
-                out += ch;
-                escape = true;
-                continue;
-            }
-            if (ch === '"') {
-                out += ch;
-                inString = !inString;
-                continue;
-            }
-            if (inString) {
-                if (ch === '\n') {
-                    out += '\\n';
-                    continue;
-                }
-                if (ch === '\r') {
-                    out += '\\r';
-                    continue;
-                }
-                if (ch === '\t') {
-                    out += '\\t';
-                    continue;
-                }
-            }
-            out += ch;
-        }
-        return out;
-    }
-
-    function parseLooseJson(jsonText) {
-        try {
-            return { parsed: JSON.parse(jsonText), recovered: false };
-        } catch (firstErr) {
-            const normalized = normalizeJsonish(jsonText);
-            if (normalized !== jsonText) {
-                try {
-                    return { parsed: JSON.parse(normalized), recovered: true };
-                } catch {}
-            }
-            throw firstErr;
-        }
-    }
-
-    let match;
-    while ((match = regex.exec(text)) !== null) {
-        const raw = (match[1] || '').trim();
-        const start = raw.indexOf('{');
-        const end = raw.lastIndexOf('}');
-        if (start === -1 || end === -1 || end < start) {
-            console.error(`[parseToolCalls] No JSON object found in block: ${raw.slice(0, 300)}`);
-            continue;
-        }
-        const jsonText = raw.slice(start, end + 1);
-        try {
-            const { parsed, recovered } = parseLooseJson(jsonText);
-            if (!parsed || typeof parsed.name !== 'string') {
-                console.error(`[parseToolCalls] Invalid tool_call payload: ${jsonText.slice(0, 300)}`);
-                continue;
-            }
-            if (recovered) {
-                console.warn(`[parseToolCalls] Recovered malformed tool_call JSON for ${parsed.name}`);
-            }
-            const args = (parsed.arguments && typeof parsed.arguments === 'object' && !Array.isArray(parsed.arguments))
-                ? parsed.arguments
-                : {};
-            calls.push({
-                id: `call_${uuidv4().slice(0, 8)}`,
-                name: parsed.name,
-                arguments: args,
-            });
-        } catch (err) {
-            console.error(`[parseToolCalls] Failed to parse JSON: ${jsonText.slice(0, 300)}`);
-        }
-    }
-    return calls;
-}
-
-/**
- * Strip internal XML tags that Claude may echo back from conversation context.
- * These are meant for Claude's consumption, not the end user.
- */
-function cleanResponseText(text) {
-    if (!text) return text;
-    const stripped = text
-        .replace(/<tool_thinking>[\s\S]*?<\/tool_thinking>/g, '')
-        .replace(/<tool_call>[\s\S]*?<\/tool_call>/g, '')
-        .replace(/<tool_result[\s\S]*?<\/tool_result>/g, '')
-        .replace(/<previous_response>[\s\S]*?<\/previous_response>/g, '');
-    // Collapse 3+ newlines only OUTSIDE fenced code blocks, to preserve
-    // intentional formatting inside triple-backtick fences.
-    const parts = stripped.split(/(```[\s\S]*?```)/);
-    return parts
-        .map((part, idx) => idx % 2 === 0 ? part.replace(/\n{3,}/g, '\n\n') : part)
-        .join('')
-        .trim();
-}
+// Tool-call parsing and internal bridge markup cleanup live in ./tool-parser.
 
 // ─── API app (port 3456, localhost only) ──────────────────────────────────────
 const app = express();
@@ -454,8 +342,9 @@ app.post('/v1/chat/completions', async (req, res) => {
         logEntry.thinking = !!reasoning_effort;
         if (reasoning_effort) console.log(`[${requestId}] reasoning_effort=${reasoning_effort}`);
 
+        const allowedToolNames = new Set(tools.map(t => t.function?.name || t.name).filter(Boolean));
         if (tools.length > 0) {
-            const toolNames = tools.map(t => t.function?.name || t.name).filter(Boolean);
+            const toolNames = Array.from(allowedToolNames);
             console.log(`[${requestId}] tools:[${toolNames.join(',')}]`);
         }
 
@@ -821,8 +710,18 @@ app.post('/v1/chat/completions', async (req, res) => {
             },
         };
 
-        // Parse <tool_call> blocks from Claude's response
-        const toolCalls = parseToolCalls(finalText || '');
+        // Parse <tool_call> blocks from Claude's response. Exact XML is preferred;
+        // one unambiguous malformed block can be repaired, but only for declared tools.
+        const toolCallResult = parseToolCallsDetailed(finalText || '', { allowedToolNames });
+        const toolCalls = toolCallResult.calls;
+        if (toolCallResult.repaired) {
+            console.warn(`[${requestId}] WARNING malformed_tool_call_repaired close=${toolCallResult.closeTag || 'unknown'} tool=${toolCalls[0]?.name || 'unknown'}`);
+        } else if (toolCallResult.hadToolCallMarkup && toolCalls.length === 0) {
+            console.warn(`[${requestId}] WARNING malformed_tool_call_unrecoverable reason=${toolCallResult.malformedReason || 'unknown'}`);
+        }
+        if (toolCallResult.recoveredJson) {
+            console.warn(`[${requestId}] WARNING malformed_tool_call_json_recovered`);
+        }
 
         if (toolCalls.length > 0) {
             // Claude requested tools → return as OpenAI tool_calls for OC to execute

--- a/src/server.js
+++ b/src/server.js
@@ -547,6 +547,7 @@ app.post('/v1/chat/completions', async (req, res) => {
                         logEntry.resumeMethod = 'refresh';
                         logEntry.refreshPrompt = compactResult.promptText;
                         logEntry.refreshSystemPrompt = compactResult.systemPrompt;
+                        logEntry.refreshAttachmentBlocks = compactResult.attachmentBlocks || [];
                         logEntry.pendingCompactionHash = compactionHash;
                         purgeCliSession(oldSid);
                         channelMap.delete(routingKey);
@@ -562,6 +563,7 @@ app.post('/v1/chat/completions', async (req, res) => {
         let promptText;
         let combinedSystemPrompt;
         let sessionId;
+        let attachmentBlocks = [];
 
         // Always build system prompt (not persisted in CLI session)
         const { systemPrompt: devSystemPrompt } = convertMessages(messages);
@@ -574,25 +576,29 @@ app.post('/v1/chat/completions', async (req, res) => {
             // Resume mode: only send new messages as prompt
             sessionId = resumeSessionId;
             // 1) Try tool loop extraction (messages after last assistant tool_calls)
-            const newText = extractNewMessages(messages);
+            const newToolLoop = extractNewMessages(messages);
             // 2) Try conversation continuation (messages after last assistant message)
-            const newUserText = !newText ? extractNewUserMessages(messages) : null;
-            if (newText) {
-                promptText = newText;
+            const newCont = !newToolLoop ? extractNewUserMessages(messages) : null;
+            if (newToolLoop) {
+                promptText = newToolLoop.newText;
+                attachmentBlocks = newToolLoop.attachmentBlocks || [];
                 logEntry.resumeMethod = 'tool_loop';
-                console.log(`[${requestId}] RESUME session=${sessionId.slice(0, 8)} newPromptLen=${promptText.length} (tool loop)`);
+                console.log(`[${requestId}] RESUME session=${sessionId.slice(0, 8)} newPromptLen=${promptText.length} (tool loop)${attachmentBlocks.length ? ` +${attachmentBlocks.length} attachment(s)` : ''}`);
                 pushActivity(requestId, `🔄 resuming session (${promptText.length} chars new)`);
-            } else if (newUserText) {
-                promptText = newUserText;
+            } else if (newCont) {
+                promptText = newCont.newText;
+                attachmentBlocks = newCont.attachmentBlocks || [];
                 logEntry.resumeMethod = 'continuation';
-                console.log(`[${requestId}] RESUME session=${sessionId.slice(0, 8)} newPromptLen=${promptText.length} (continuation)`);
+                console.log(`[${requestId}] RESUME session=${sessionId.slice(0, 8)} newPromptLen=${promptText.length} (continuation)${attachmentBlocks.length ? ` +${attachmentBlocks.length} attachment(s)` : ''}`);
                 pushActivity(requestId, `🔄 resuming session (${promptText.length} chars new)`);
             } else {
                 // Fallback: nothing new to send, use full history as new session
                 logEntry.resumeMethod = 'fallback';
                 isResume = false;
                 sessionId = uuidv4();
-                promptText = convertMessages(messages).promptText;
+                const full = convertMessages(messages);
+                promptText = full.promptText;
+                attachmentBlocks = full.attachmentBlocks || [];
                 console.log(`[${requestId}] RESUME fallback → new session=${sessionId.slice(0, 8)}`);
                 pushActivity(requestId, `⏳ thinking... (${tools.length} tools) [resume fallback]`);
             }
@@ -605,12 +611,16 @@ app.post('/v1/chat/completions', async (req, res) => {
                 if (refreshSys) {
                     combinedSystemPrompt = `${refreshSys}${toolInstructions}`;
                 }
+                attachmentBlocks = logEntry.refreshAttachmentBlocks || [];
                 delete logEntry.refreshPrompt;
                 delete logEntry.refreshSystemPrompt;
+                delete logEntry.refreshAttachmentBlocks;
                 console.log(`[${requestId}] NEW session=${sessionId.slice(0, 8)} (context refresh)`);
                 pushActivity(requestId, `🔄 context refresh → new session (${promptText.length} chars)`);
             } else {
-                promptText = convertMessages(messages).promptText;
+                const full = convertMessages(messages);
+                promptText = full.promptText;
+                attachmentBlocks = full.attachmentBlocks || [];
                 console.log(`[${requestId}] NEW session=${sessionId.slice(0, 8)}`);
                 pushActivity(requestId, `⏳ thinking... (${tools.length} tools)`);
             }
@@ -664,7 +674,7 @@ app.post('/v1/chat/completions', async (req, res) => {
         let finalText;
         let finalUsage = { input_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0, output_tokens: 0, cost_usd: 0 };
         try {
-            ({ text: finalText, usage: finalUsage } = await runClaude(combinedSystemPrompt, promptText, model, onChunk, ac.signal, reasoning_effort, sessionId, isResume));
+            ({ text: finalText, usage: finalUsage } = await runClaude(combinedSystemPrompt, promptText, model, onChunk, ac.signal, reasoning_effort, sessionId, isResume, attachmentBlocks));
         } catch (err) {
             const errMessage = err?.message || 'Unknown Claude error';
             const emptyCompletion = /empty response/i.test(errMessage);
@@ -704,11 +714,12 @@ app.post('/v1/chat/completions', async (req, res) => {
                     if (compactResult.systemPrompt) {
                         combinedSystemPrompt = `${compactResult.systemPrompt}${toolInstructions}`;
                     }
+                    attachmentBlocks = compactResult.attachmentBlocks || [];
                 }
                 logEntry.promptLen = promptText.length;
                 console.log(`[${requestId}] Retry path: new session=${sessionId.slice(0, 8)} promptLen=${promptText.length}`);
                 try {
-                    ({ text: finalText, usage: finalUsage } = await runClaude(combinedSystemPrompt, promptText, model, onChunk, ac.signal, reasoning_effort, sessionId, false));
+                    ({ text: finalText, usage: finalUsage } = await runClaude(combinedSystemPrompt, promptText, model, onChunk, ac.signal, reasoning_effort, sessionId, false, attachmentBlocks));
                 } catch (retryErr) {
                     console.error(`[${requestId}] Retry also failed: ${retryErr.message}`);
                     logEntry.status = 'error';

--- a/src/server.js
+++ b/src/server.js
@@ -306,6 +306,22 @@ function parseToolCalls(text) {
     return calls;
 }
 
+function getAvailableToolNames(tools) {
+    if (!Array.isArray(tools)) return [];
+    return tools.map(tool => tool?.function?.name || tool?.name).filter(Boolean);
+}
+
+function filterToolCalls(toolCalls, availableToolNames) {
+    const allowed = new Set(availableToolNames || []);
+    const valid = [];
+    const invalid = [];
+    for (const call of toolCalls || []) {
+        if (allowed.has(call.name)) valid.push(call);
+        else invalid.push(call);
+    }
+    return { valid, invalid };
+}
+
 /**
  * Strip internal XML tags that Claude may echo back from conversation context.
  * These are meant for Claude's consumption, not the end user.
@@ -767,7 +783,14 @@ app.post('/v1/chat/completions', async (req, res) => {
         };
 
         // Parse <tool_call> blocks from Claude's response
-        const toolCalls = parseToolCalls(finalText || '');
+        const parsedToolCalls = parseToolCalls(finalText || '');
+        const availableToolNames = getAvailableToolNames(tools);
+        const { valid: toolCalls, invalid: invalidToolCalls } = filterToolCalls(parsedToolCalls, availableToolNames);
+        if (invalidToolCalls.length > 0) {
+            console.warn(`[${requestId}] filtered unavailable tool_calls: [${invalidToolCalls.map(tc => tc.name).join(', ')}]`);
+            pushActivity(requestId, `filtered unavailable tool_calls: [${invalidToolCalls.map(tc => tc.name).join(', ')}]`);
+            logEntry.activity.push(`filtered unavailable tool_calls: [${invalidToolCalls.map(tc => tc.name).join(', ')}]`);
+        }
 
         if (toolCalls.length > 0) {
             // Claude requested tools → return as OpenAI tool_calls for OC to execute
@@ -784,17 +807,9 @@ app.post('/v1/chat/completions', async (req, res) => {
             console.log(`[${requestId}] sessionMap: stored ${toolCalls.length} tool_call_ids for session=${sessionId.slice(0, 8)} (total=${sessionMap.size})`);
 
             if (isStream) {
-                // Send any text before tool calls
-                if (textBeforeTools) {
-                    const textChunk = {
-                        id: completionId, object: 'chat.completion.chunk',
-                        created: Math.floor(Date.now() / 1000), model,
-                        choices: [{ index: 0, delta: { role: 'assistant', content: textBeforeTools }, finish_reason: null }],
-                    };
-                    res.write(`data: ${JSON.stringify(textChunk)}\n\n`);
-                }
-
-                // Send tool_calls delta
+                // Suppress any partial assistant prose before tool calls.
+                // Tool-use turns should only surface the tool_calls payload until
+                // the loop completes and a final verified reply is ready.
                 const tcDelta = {
                     id: completionId, object: 'chat.completion.chunk',
                     created: Math.floor(Date.now() / 1000), model,
@@ -832,7 +847,7 @@ app.post('/v1/chat/completions', async (req, res) => {
                     created: Math.floor(Date.now() / 1000), model,
                     choices: [{ index: 0, message: {
                         role: 'assistant',
-                        content: textBeforeTools || null,
+                        content: null,
                         tool_calls: toolCalls.map((tc, i) => ({
                             id: tc.id, index: i, type: 'function',
                             function: { name: tc.name, arguments: JSON.stringify(tc.arguments) },

--- a/src/server.js
+++ b/src/server.js
@@ -7,7 +7,7 @@ const { v4: uuidv4 } = require('uuid');
 const { convertMessages, convertMessagesCompact, extractNewMessages, extractNewUserMessages } = require('./convert');
 const { buildToolInstructions } = require('./tools');
 const { runClaude, getContextWindow, clearSessionAlias } = require('./claude');
-const { cleanResponseText, parseToolCallsDetailed } = require('./tool-parser');
+const { cleanResponseText, hasInternalBridgeMarkup, parseToolCallsDetailed, redactSensitivePreview } = require('./tool-parser');
 
 // --- Session cleanup ---
 // Claude CLI subprocess runs with cwd=/tmp. On macOS /tmp → /private/tmp,
@@ -717,11 +717,13 @@ app.post('/v1/chat/completions', async (req, res) => {
         if (toolCallResult.repaired) {
             console.warn(`[${requestId}] WARNING malformed_tool_call_repaired close=${toolCallResult.closeTag || 'unknown'} tool=${toolCalls[0]?.name || 'unknown'}`);
         } else if (toolCallResult.hadToolCallMarkup && toolCalls.length === 0) {
-            console.warn(`[${requestId}] WARNING malformed_tool_call_unrecoverable reason=${toolCallResult.malformedReason || 'unknown'}`);
+            console.warn(`[${requestId}] WARNING malformed_tool_call_unrecoverable reason=${toolCallResult.malformedReason || 'unknown'} preview=${redactSensitivePreview(finalText || '')}`);
         }
         if (toolCallResult.recoveredJson) {
             console.warn(`[${requestId}] WARNING malformed_tool_call_json_recovered`);
         }
+
+        const rawMarkupPresent = hasInternalBridgeMarkup(finalText || '');
 
         if (toolCalls.length > 0) {
             // Claude requested tools → return as OpenAI tool_calls for OC to execute
@@ -788,8 +790,13 @@ app.post('/v1/chat/completions', async (req, res) => {
                 });
             }
         } else {
-            // No tool calls — return clean text with finish_reason: stop
-            const cleanText = cleanResponseText(finalText);
+            // No tool calls — return clean text with finish_reason: stop.
+            // Fail closed if raw bridge markup somehow survives parsing.
+            let cleanText = cleanResponseText(finalText);
+            if (rawMarkupPresent) {
+                console.warn(`[${requestId}] WARNING suppressed_internal_bridge_markup preview=${redactSensitivePreview(finalText || '')}`);
+                cleanText = '';
+            }
             if (cleanText) sendChunk(cleanText);
 
             if (isStream) {

--- a/src/server.js
+++ b/src/server.js
@@ -361,7 +361,7 @@ app.post('/v1/chat/completions', async (req, res) => {
     pushLog(logEntry); // appear in dashboard immediately as 'pending'
 
     try {
-        const { messages = [], tools = [], model = 'claude-opus-4-7', stream = true, reasoning_effort } = req.body;
+        const { messages = [], tools = [], model = 'claude-opus-4-7', stream = true, reasoning_effort, user } = req.body;
         stats.lastModel = model;
         logEntry.model = model;
         logEntry.contextWindow = getContextWindow(model);
@@ -425,12 +425,18 @@ app.post('/v1/chat/completions', async (req, res) => {
         let isResume = false;
         let resumeSessionId = null;
 
-        // Extract OC conversation identity + agent name
+        // Extract conversation identity.
+        // Priority:
+        // 1. OpenClaw-style conversation metadata + agent name, for multi-agent channels.
+        // 2. OpenAI-compatible `user` field, for OpenAI clients and raw API tests.
+        // Without the `user` fallback, plain OpenAI requests never hit channelMap and
+        // every turn starts a fresh Claude CLI session.
         const convLabel = extractConversationLabel(messages);
         const agentName = extractAgentName(messages);
+        const openAiUser = typeof user === 'string' && user.trim() ? user.trim() : null;
         const routingKey = convLabel
             ? (agentName ? `${convLabel}::${agentName}` : convLabel)
-            : null;
+            : (openAiUser ? `openai-user:${openAiUser}` : null);
         if (routingKey) {
             console.log(`[${requestId}] OC channel: "${convLabel}" agent: "${agentName || '(none)'}" routingKey: "${routingKey}"`);
         }
@@ -591,6 +597,18 @@ app.post('/v1/chat/completions', async (req, res) => {
                 logEntry.resumeMethod = 'continuation';
                 console.log(`[${requestId}] RESUME session=${sessionId.slice(0, 8)} newPromptLen=${promptText.length} (continuation)${attachmentBlocks.length ? ` +${attachmentBlocks.length} attachment(s)` : ''}`);
                 pushActivity(requestId, `🔄 resuming session (${promptText.length} chars new)`);
+            } else if (routingKey && !messages.some(m => m.role === 'assistant')) {
+                // OpenAI-compatible clients often send only the latest user message
+                // while relying on the `user` routing key for continuity. In that
+                // shape there is no assistant anchor for extractNewUserMessages(),
+                // but we still should resume the mapped Claude CLI session and send
+                // the current user turn.
+                const full = convertMessages(messages);
+                promptText = full.promptText;
+                attachmentBlocks = full.attachmentBlocks || [];
+                logEntry.resumeMethod = 'user_key_continuation';
+                console.log(`[${requestId}] RESUME session=${sessionId.slice(0, 8)} promptLen=${promptText.length} (user key continuation)`);
+                pushActivity(requestId, `🔄 resuming session (${promptText.length} chars via user key)`);
             } else {
                 // Fallback: nothing new to send, use full history as new session
                 logEntry.resumeMethod = 'fallback';
@@ -982,8 +1000,10 @@ statusApp.post('/cleanup', (req, res) => {
     res.json(result);
 });
 
-// SPA fallback — serve index.html for any non-API route
-statusApp.get('*', (req, res) => {
+// SPA fallback — serve index.html for any non-API route. Express 5 uses
+// path-to-regexp v8, where bare '*' is invalid; use middleware as the
+// catch-all instead.
+statusApp.use((req, res) => {
     res.sendFile(path.join(__dirname, '../dashboard/dist/index.html'));
 });
 

--- a/src/tool-parser.js
+++ b/src/tool-parser.js
@@ -187,6 +187,21 @@ function parseToolCalls(text, allowedToolNames) {
     return parseToolCallsDetailed(text, { allowedToolNames }).calls;
 }
 
+function hasInternalBridgeMarkup(text) {
+    if (!text) return false;
+    return /<(?:tool_call|tool_result|tool_thinking|previous_response)\b|<\/(?:tool_call|tool_char|tool_result|tool_thinking|previous_response)>/i.test(String(text));
+}
+
+function redactSensitivePreview(text, maxLen = 400) {
+    if (!text) return '';
+    return String(text)
+        .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, 'sk-***')
+        .replace(/\b(OPENAI_API_KEY|ANTHROPIC_API_KEY|OPENROUTER_API_KEY|DEEPSEEK_API_KEY)\b\s*[:=]\s*[^\s"']+/gi, '$1=***')
+        .replace(/\b(token|api[_-]?key|secret|password)\b\s*[:=]\s*[^\s,}\]"']+/gi, '$1=***')
+        .slice(0, maxLen)
+        .replace(/\n/g, '\\n');
+}
+
 function cleanResponseText(text) {
     if (!text) return text;
     const stripped = String(text)
@@ -210,6 +225,8 @@ function cleanResponseText(text) {
 module.exports = {
     cleanResponseText,
     extractBalancedJsonObjects,
+    hasInternalBridgeMarkup,
     parseToolCalls,
     parseToolCallsDetailed,
+    redactSensitivePreview,
 };

--- a/src/tool-parser.js
+++ b/src/tool-parser.js
@@ -1,0 +1,215 @@
+'use strict';
+
+const { v4: uuidv4 } = require('uuid');
+
+function normalizeJsonish(text) {
+    let out = '';
+    let inString = false;
+    let escape = false;
+    for (const ch of text) {
+        if (escape) {
+            out += ch;
+            escape = false;
+            continue;
+        }
+        if (ch === '\\') {
+            out += ch;
+            escape = true;
+            continue;
+        }
+        if (ch === '"') {
+            out += ch;
+            inString = !inString;
+            continue;
+        }
+        if (inString) {
+            if (ch === '\n') { out += '\\n'; continue; }
+            if (ch === '\r') { out += '\\r'; continue; }
+            if (ch === '\t') { out += '\\t'; continue; }
+        }
+        out += ch;
+    }
+    return out;
+}
+
+function parseLooseJson(jsonText) {
+    try {
+        return { parsed: JSON.parse(jsonText), recovered: false };
+    } catch (firstErr) {
+        const normalized = normalizeJsonish(jsonText);
+        if (normalized !== jsonText) {
+            try {
+                return { parsed: JSON.parse(normalized), recovered: true };
+            } catch {}
+        }
+        throw firstErr;
+    }
+}
+
+function isAllowedToolName(name, allowedToolNames) {
+    if (!allowedToolNames || allowedToolNames.size === 0) return true;
+    return allowedToolNames.has(name);
+}
+
+function coerceToolCall(raw, allowedToolNames) {
+    const start = raw.indexOf('{');
+    const end = raw.lastIndexOf('}');
+    if (start === -1 || end === -1 || end < start) {
+        return { error: 'no_json_object', preview: raw.slice(0, 300) };
+    }
+    const jsonText = raw.slice(start, end + 1);
+    try {
+        const { parsed, recovered } = parseLooseJson(jsonText);
+        if (!parsed || typeof parsed.name !== 'string') {
+            return { error: 'invalid_payload', preview: jsonText.slice(0, 300) };
+        }
+        if (!isAllowedToolName(parsed.name, allowedToolNames)) {
+            return { error: 'tool_not_allowed', name: parsed.name, preview: jsonText.slice(0, 300) };
+        }
+        const args = (parsed.arguments && typeof parsed.arguments === 'object' && !Array.isArray(parsed.arguments))
+            ? parsed.arguments
+            : {};
+        return {
+            call: {
+                id: `call_${uuidv4().slice(0, 8)}`,
+                name: parsed.name,
+                arguments: args,
+            },
+            recovered,
+        };
+    } catch {
+        return { error: 'json_parse_failed', preview: jsonText.slice(0, 300) };
+    }
+}
+
+function extractBalancedJsonObjects(text) {
+    const objects = [];
+    let inString = false;
+    let escape = false;
+    let depth = 0;
+    let start = -1;
+
+    for (let i = 0; i < text.length; i += 1) {
+        const ch = text[i];
+        if (escape) { escape = false; continue; }
+        if (ch === '\\') { escape = true; continue; }
+        if (ch === '"') { inString = !inString; continue; }
+        if (inString) continue;
+
+        if (ch === '{') {
+            if (depth === 0) start = i;
+            depth += 1;
+        } else if (ch === '}') {
+            if (depth === 0) continue;
+            depth -= 1;
+            if (depth === 0 && start !== -1) {
+                objects.push(text.slice(start, i + 1));
+                start = -1;
+            }
+        }
+    }
+    return objects;
+}
+
+function parseExactToolCalls(text, allowedToolNames) {
+    const regex = /<tool_call>\s*([\s\S]*?)\s*<\/tool_call>/g;
+    const calls = [];
+    const errors = [];
+    let recoveredJson = false;
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+        const raw = (match[1] || '').trim();
+        const result = coerceToolCall(raw, allowedToolNames);
+        if (result.call) {
+            calls.push(result.call);
+            if (result.recovered) recoveredJson = true;
+        } else {
+            errors.push(result);
+        }
+    }
+    return { calls, errors, recoveredJson };
+}
+
+function parseMalformedToolCall(text, allowedToolNames) {
+    const opens = [...text.matchAll(/<tool_call\b[^>]*>/g)];
+    if (opens.length !== 1) {
+        return { calls: [], repaired: false, reason: opens.length === 0 ? 'no_markup' : 'multiple_tool_call_blocks' };
+    }
+
+    const open = opens[0];
+    const bodyStart = open.index + open[0].length;
+    const tail = text.slice(bodyStart);
+    const closeCandidates = ['</tool_call>', '</tool_char>']
+        .map(tag => ({ tag, idx: tail.indexOf(tag) }))
+        .filter(c => c.idx !== -1)
+        .sort((a, b) => a.idx - b.idx);
+    const bodyEnd = closeCandidates.length > 0 ? closeCandidates[0].idx : tail.length;
+    const raw = tail.slice(0, bodyEnd).trim();
+    const jsonObjects = extractBalancedJsonObjects(raw);
+    if (jsonObjects.length !== 1) {
+        return { calls: [], repaired: false, reason: `json_object_count_${jsonObjects.length}` };
+    }
+
+    const result = coerceToolCall(jsonObjects[0], allowedToolNames);
+    if (!result.call) {
+        return { calls: [], repaired: false, reason: result.error, error: result };
+    }
+    return { calls: [result.call], repaired: true, closeTag: closeCandidates[0]?.tag || 'EOF', recoveredJson: result.recovered };
+}
+
+function parseToolCallsDetailed(text, opts = {}) {
+    const source = String(text || '');
+    const allowedToolNames = opts.allowedToolNames || null;
+    const hadToolCallMarkup = /<tool_call\b/i.test(source);
+
+    const exact = parseExactToolCalls(source, allowedToolNames);
+    if (exact.calls.length > 0) {
+        return { calls: exact.calls, repaired: false, hadToolCallMarkup, errors: exact.errors, recoveredJson: exact.recoveredJson };
+    }
+
+    if (!hadToolCallMarkup) {
+        return { calls: [], repaired: false, hadToolCallMarkup: false, errors: exact.errors };
+    }
+
+    const malformed = parseMalformedToolCall(source, allowedToolNames);
+    return {
+        calls: malformed.calls,
+        repaired: malformed.repaired,
+        hadToolCallMarkup,
+        malformedReason: malformed.reason,
+        closeTag: malformed.closeTag,
+        errors: exact.errors.concat(malformed.error ? [malformed.error] : []),
+        recoveredJson: !!malformed.recoveredJson,
+    };
+}
+
+function parseToolCalls(text, allowedToolNames) {
+    return parseToolCallsDetailed(text, { allowedToolNames }).calls;
+}
+
+function cleanResponseText(text) {
+    if (!text) return text;
+    const stripped = String(text)
+        .replace(/<tool_thinking\b[^>]*>[\s\S]*?<\/tool_thinking>/g, '')
+        .replace(/<tool_call\b[^>]*>[\s\S]*?<\/(?:tool_call|tool_char)>/g, '')
+        .replace(/<tool_call\b[^>]*>[\s\S]*$/g, '')
+        .replace(/<tool_result\b[^>]*>[\s\S]*?<\/tool_result>/g, '')
+        .replace(/<previous_response\b[^>]*>[\s\S]*?<\/previous_response>/g, '')
+        .replace(/<tool_result\b[^>]*>[\s\S]*?<\/tool_call>/g, '')
+        .replace(/<tool_call\b[^>]*>[\s\S]*?<\/tool_result>/g, '')
+        .replace(/<tool_thinking\b[^>]*>[\s\S]*?<\/tool_call>/g, '')
+        .replace(/<tool_thinking\b[^>]*>[\s\S]*?<\/tool_result>/g, '')
+        .replace(/<\/?(?:tool_thinking|tool_call|tool_result|previous_response)\b[^>]*>/g, '');
+    const parts = stripped.split(/(```[\s\S]*?```)/);
+    return parts
+        .map((part, idx) => idx % 2 === 0 ? part.replace(/\n{3,}/g, '\n\n') : part)
+        .join('')
+        .trim();
+}
+
+module.exports = {
+    cleanResponseText,
+    extractBalancedJsonObjects,
+    parseToolCalls,
+    parseToolCallsDetailed,
+};


### PR DESCRIPTION
## Problem

The brand-substitution pass on `promptText` (`OpenClaw` → session alias) in `runClaude` walks the entire string, including JSON `tool_call` arguments and `tool_result` payloads. Those regions contain literal data the orchestrator owns — filesystem paths, command output, identifiers — not prose. Rewriting them corrupts shell commands and silently desyncs the orchestrator's view of disk from what's actually on the filesystem.

**Example.** An orchestrator that emits

```
ls /Users/alex/.openclaw/skills/
```

ends up running

```
ls /Users/alex/.<alias>/skills/
```

on the host, because the brand pass rewrote the path before the tool call left the bridge. The inbound restore reverses it for the orchestrator's view, so the corruption is *invisible* to the client — they see a clean response while the wrong directory was actually listed.

## Fix

Type-aware substitution via sentinel markers. Convert.js already knows which segments of `promptText` are tool-block content (it builds them); we wrap those segments so the brand pass in claude.js can skip them.

- **`convert.js`** wraps every `<tool_call>` and `<tool_result>` block at render time in non-printable sentinel markers (`NOSCRUB_OPEN` / `NOSCRUB_CLOSE`, `\x1E`/`\x1F` pair). Markers are built from char codes so the brand pass can never substitute them. Sentinels are added in all four converter functions (`convertMessages`, `convertMessagesCompact`, `extractNewMessages`, `extractNewUserMessages`).
- **`claude.js`** adds `brandSubstituteWithSkipRegions()` which splits on sentinel pairs, applies the existing `OpenClaw` → alias / `openclaw` → `aliasLower` substitution **only to outside-sentinel chunks**, and strips the markers before the text reaches the CLI.
- `runClaude()` swaps the inline `.replace(/OpenClaw/g, alias).replace(/openclaw/g, aliasLower)` chain for `brandSubstituteWithSkipRegions(promptText, alias, aliasLower)`.
- `systemPrompt` continues through the full `scrubOutbound` pass unchanged — it's all prose.
- Inbound restoration is unchanged: tool regions that pass through unsubstituted have nothing to restore, and prose still round-trips via the existing alias map.

Behavior scope is preserved — this still only does brand substitution on `promptText` (no pattern-token scrubbing added). The patch is a strict subset of the prior behavior plus a region-skip.

## Verification

Standalone test (mocks `child_process.spawn` to capture stdin):

```
convert sentinel pairs: open=2 close=2
--- captured stdin sent to "claude" ---
User: List projects.

<previous_response>
<tool_call>
{"name": "exec", "arguments": {"command":"ls /Users/alex/.openclaw/skills/"}}
</tool_call>
</previous_response>

<tool_result name="exec" tool_call_id="c1">
/Users/alex/.openclaw/skills/apple
OpenClaw lives here.
</tool_result>

User: Summarize SkyGem.
protected regions survived verbatim: true
prose got brand-substituted:         true
sentinels stripped before CLI:       true
PASS
```

Both invariants hold:
1. `.openclaw` paths and `OpenClaw` mentions **inside** tool blocks pass through verbatim.
2. `OpenClaw` mentions in user prose still get substituted (`Summarize OpenClaw.` → `Summarize SkyGem.`).
3. Sentinels are stripped before the CLI sees the text.

## Origin

Discovered in a downstream Hermes fork (`Kyzcreig/hermes-claude-bridge`) where the same bug shape — same scrubber design — corrupted real filesystem operations. The fix was developed and verified there first, then back-ported here in its minimal form. Both forks now run this patch in production.